### PR TITLE
Fixes for CubeSea hero cubes

### DIFF
--- a/samples/01-vr-input.html
+++ b/samples/01-vr-input.html
@@ -163,7 +163,7 @@ found in the LICENSE file.
       }
 
       // Main rendering loop
-      function onAnimationFrame () {
+      function onAnimationFrame (t) {
         stats.begin();
 
         // The normal requestAnimationFrame is used here because the scene is
@@ -178,10 +178,10 @@ found in the LICENSE file.
           vrDisplay.getFrameData(frameData);
 
           // Render the scene using the view matrix for one of the eyes.
-          cubeSea.render(projectionMat, frameData.leftViewMatrix, stats);
+          cubeSea.render(projectionMat, frameData.leftViewMatrix, stats, t);
         } else {
           // If no VRDisplay was found render the scene using an identity matrix.
-          cubeSea.render(projectionMat, identityMat, stats);
+          cubeSea.render(projectionMat, identityMat, stats, t);
         }
 
         // Render the FPS counter.

--- a/samples/js/vr-cube-sea.js
+++ b/samples/js/vr-cube-sea.js
@@ -197,7 +197,11 @@ window.VRCubeSea = (function () {
       mat4.multiply(this.heroModelViewMat, modelViewMat, this.heroRotationMat);
       gl.uniformMatrix4fv(program.uniform.modelViewMat, false, this.heroModelViewMat);
 
-      mat3.normalFromMat4(this.normalMat, this.heroRotationMat);
+      // We know that the additional model matrix is a pure rotation,
+      // so we can just use the non-position parts of the matrix
+      // directly, this is cheaper than the transpose+inverse that
+      // normalFromMat4 would do.
+      mat3.fromMat4(this.normalMat, this.heroRotationMat);
       gl.uniformMatrix3fv(program.uniform.normalMat, false, this.normalMat);
 
       gl.drawElements(gl.TRIANGLES, this.heroCount, gl.UNSIGNED_SHORT, this.heroOffset * 2);


### PR DESCRIPTION
- Add timestamp handling + hero cube drawing to 01-vr-input

- use mat3.fromMat4 instead of the more expensive normalFromMat4,
  input is a pure rotation matrix that doesn't need inverse+transpose.