### PR TITLE
Change the debug geometry's default light to match CubeSea

### DIFF
--- a/samples/js/third-party/wglu/wglu-debug-geometry.js
+++ b/samples/js/third-party/wglu/wglu-debug-geometry.js
@@ -230,7 +230,7 @@ var WGLUDebugGeometry = (function() {
 
   DebugGeometry.prototype._bindUniformsRaw = function(model, color, light) {
     if (!color) { color = [1, 0, 0, 1]; }
-    if (!light) { light = [1, 1, 1]; }
+    if (!light) { light = [0.75, 0.5, 1.0]; }  // Should match vr-cube-sea.js
     var lightVec = vec3.fromValues(light[0], light[1], light[2]);
     vec3.normalize(lightVec, lightVec);
 


### PR DESCRIPTION
They were already close, but this way it'll be a bit more consistent.