### PR TITLE
Re-enable high precision timing for FPS stats

### DIFF
--- a/samples/js/third-party/wglu/wglu-stats.js
+++ b/samples/js/third-party/wglu/wglu-stats.js
@@ -446,7 +446,7 @@ var WGLUStats = (function() {
     };
   }
 
-  var now = /*( performance && performance.now ) ? performance.now.bind( performance ) :*/ Date.now;
+  var now = (window.performance && performance.now) ? performance.now.bind(performance) : Date.now;
 
   var Stats = function(gl) {
     this.gl = gl;


### PR DESCRIPTION
The original code was throwing a ReferenceError in the API presence
check, avoid that so that it can fall back to Date.now.