### PR TITLE
Add performance monitoring to console behind URL parameter

### DIFF
--- a/samples/01-vr-input.html
+++ b/samples/01-vr-input.html
@@ -111,7 +111,9 @@ found in the LICENSE file.
       var texture = textureLoader.loadTexture("media/textures/cube-sea.png");
       var cubeSea = new VRCubeSea(gl, texture);
 
-      var stats = new WGLUStats(gl);
+      var enablePerformanceMonitoring = WGLUUrl.getBool(
+          'enablePerformanceMonitoring', false);
+      var stats = new WGLUStats(gl, enablePerformanceMonitoring);
 
       function onResize () {
         webglCanvas.width = webglCanvas.offsetWidth * window.devicePixelRatio;

--- a/samples/02-stereo-rendering.html
+++ b/samples/02-stereo-rendering.html
@@ -105,7 +105,9 @@ found in the LICENSE file.
       var texture = textureLoader.loadTexture("media/textures/cube-sea.png");
       var cubeSea = new VRCubeSea(gl, texture);
 
-      var stats = new WGLUStats(gl);
+      var enablePerformanceMonitoring = WGLUUrl.getBool(
+          'enablePerformanceMonitoring', false);
+      var stats = new WGLUStats(gl, enablePerformanceMonitoring);
 
       function onResize () {
         webglCanvas.width = webglCanvas.offsetWidth * window.devicePixelRatio;

--- a/samples/03-vr-presentation.html
+++ b/samples/03-vr-presentation.html
@@ -123,7 +123,9 @@ found in the LICENSE file.
       var texture = textureLoader.loadTexture("media/textures/cube-sea.png");
       var cubeSea = new VRCubeSea(gl, texture);
 
-      var stats = new WGLUStats(gl);
+      var enablePerformanceMonitoring = WGLUUrl.getBool(
+          'enablePerformanceMonitoring', false);
+      var stats = new WGLUStats(gl, enablePerformanceMonitoring);
 
       var presentingMessage = document.getElementById("presenting-message");
 

--- a/samples/04-simple-mirroring.html
+++ b/samples/04-simple-mirroring.html
@@ -124,7 +124,9 @@ found in the LICENSE file.
         var textureLoader = new WGLUTextureLoader(gl);
         var texture = textureLoader.loadTexture("media/textures/cube-sea.png");
         cubeSea = new VRCubeSea(gl, texture);
-        stats = new WGLUStats(gl);
+        var enablePerformanceMonitoring = WGLUUrl.getBool(
+            'enablePerformanceMonitoring', false);
+        stats = new WGLUStats(gl, enablePerformanceMonitoring);
 
         // Wait until we have a WebGL context to resize and start rendering.
         window.addEventListener("resize", onResize, false);

--- a/samples/04b-simple-mirroring-2.html
+++ b/samples/04b-simple-mirroring-2.html
@@ -139,7 +139,9 @@ found in the LICENSE file.
         var textureLoader = new WGLUTextureLoader(gl);
         var texture = textureLoader.loadTexture("media/textures/cube-sea.png");
         cubeSea = new VRCubeSea(gl, texture);
-        stats = new WGLUStats(gl);
+        var enablePerformanceMonitoring = WGLUUrl.getBool(
+            'enablePerformanceMonitoring', false);
+        stats = new WGLUStats(gl, enablePerformanceMonitoring);
 
         window.addEventListener("resize", onResize, false);
         onResize();

--- a/samples/05-room-scale.html
+++ b/samples/05-room-scale.html
@@ -123,7 +123,9 @@ found in the LICENSE file.
         // default space size like 2 meters by 2 meters as a placeholder.
         cubeIsland = new VRCubeIsland(gl, texture, 2, 2);
 
-        stats = new WGLUStats(gl);
+        var enablePerformanceMonitoring = WGLUUrl.getBool(
+            'enablePerformanceMonitoring', false);
+        stats = new WGLUStats(gl, enablePerformanceMonitoring);
         debugGeom = new WGLUDebugGeometry(gl);
 
         // Wait until we have a WebGL context to resize and start rendering.

--- a/samples/06-vr-audio.html
+++ b/samples/06-vr-audio.html
@@ -129,7 +129,9 @@ found in the LICENSE file.
           cubeIsland = new VRCubeIsland(gl, texture, 2, 2);
         }
 
-        stats = new WGLUStats(gl);
+        var enablePerformanceMonitoring = WGLUUrl.getBool(
+            'enablePerformanceMonitoring', false);
+        stats = new WGLUStats(gl, enablePerformanceMonitoring);
         debugGeom = new WGLUDebugGeometry(gl);
 
         // Wait until we have a WebGL context to resize and start rendering.

--- a/samples/07-advanced-mirroring.html
+++ b/samples/07-advanced-mirroring.html
@@ -125,7 +125,9 @@ found in the LICENSE file.
         // third person view.
         cubeIsland = new VRCubeIsland(gl, texture, 2, 2);
 
-        stats = new WGLUStats(gl);
+        var enablePerformanceMonitoring = WGLUUrl.getBool(
+            'enablePerformanceMonitoring', false);
+        stats = new WGLUStats(gl, enablePerformanceMonitoring);
         debugGeom = new WGLUDebugGeometry(gl);
 
         // Wait until we have a WebGL context to resize and start rendering.

--- a/samples/08-dynamic-resolution.html
+++ b/samples/08-dynamic-resolution.html
@@ -128,7 +128,9 @@ found in the LICENSE file.
         var textureLoader = new WGLUTextureLoader(gl);
         var texture = textureLoader.loadTexture("media/textures/cube-sea.png");
         cubeSea = new VRCubeSea(gl, texture);
-        stats = new WGLUStats(gl);
+        var enablePerformanceMonitoring = WGLUUrl.getBool(
+            'enablePerformanceMonitoring', false);
+        stats = new WGLUStats(gl, enablePerformanceMonitoring);
 
         window.addEventListener("resize", onResize, false);
         onResize();

--- a/samples/XX-360-panorama.html
+++ b/samples/XX-360-panorama.html
@@ -113,7 +113,9 @@ found in the LICENSE file.
         panorama = new VRPanorama(gl);
         panorama.setImage("media/textures/pano_4k.jpg");
 
-        stats = new WGLUStats(gl);
+        var enablePerformanceMonitoring = WGLUUrl.getBool(
+            'enablePerformanceMonitoring', false);
+        stats = new WGLUStats(gl, enablePerformanceMonitoring);
 
         // Wait until we have a WebGL context to resize and start rendering.
         window.addEventListener("resize", onResize, false);

--- a/samples/XX-vr-controllers.html
+++ b/samples/XX-vr-controllers.html
@@ -129,7 +129,9 @@ found in the LICENSE file.
 
         cubeIsland = new VRCubeIsland(gl, texture, 2, 2);
 
-        stats = new WGLUStats(gl);
+        var enablePerformanceMonitoring = WGLUUrl.getBool(
+            'enablePerformanceMonitoring', false);
+        stats = new WGLUStats(gl, enablePerformanceMonitoring);
         debugGeom = new WGLUDebugGeometry(gl);
 
         // Wait until we have a WebGL context to resize and start rendering.

--- a/samples/js/third-party/wglu/wglu-stats.js
+++ b/samples/js/third-party/wglu/wglu-stats.js
@@ -448,8 +448,9 @@ var WGLUStats = (function() {
 
   var now = (window.performance && performance.now) ? performance.now.bind(performance) : Date.now;
 
-  var Stats = function(gl) {
+  var Stats = function(gl, enablePerformanceMonitoring) {
     this.gl = gl;
+    this.enablePerformanceMonitoring = enablePerformanceMonitoring;
 
     this.sevenSegmentText = new SevenSegmentText(gl);
 
@@ -460,6 +461,7 @@ var WGLUStats = (function() {
     this.fpsAverage = 0;
     this.fpsSum = 0;
     this.fpsMin = 0;
+    this.fpsStep = enablePerformanceMonitoring ? 1000 : 250;
 
     this.orthoProjMatrix = new Float32Array(16);
     this.orthoViewMatrix = new Float32Array(16);
@@ -551,12 +553,16 @@ var WGLUStats = (function() {
     this.fpsSum += frameFps;
     this.frames++;
 
-    if (time > this.prevGraphUpdateTime + 250) {
+    if (time > this.prevGraphUpdateTime + this.fpsStep) {
       this.fpsAverage = Math.round(this.fpsSum / this.frames);
 
       // Draw both average and minimum FPS for this period
       // so that dropped frames are more clearly visible.
       this.updateGraph(this.fpsMin, this.fpsAverage);
+      if (this.enablePerformanceMonitoring) {
+        console.log("Average FPS: " + this.fpsAverage + " " +
+                    "Min FPS: " + this.fpsMin);
+      }
 
       this.prevGraphUpdateTime = time;
       this.frames = 0;

--- a/samples/test-canvas-attributes.html
+++ b/samples/test-canvas-attributes.html
@@ -26,6 +26,7 @@ found in the LICENSE file.
     <script src="js/third-party/wglu/wglu-program.js"></script>
     <script src="js/third-party/wglu/wglu-stats.js"></script>
     <script src="js/third-party/wglu/wglu-texture.js"></script>
+    <script src="js/third-party/wglu/wglu-url.js"></script>
 
     <script src="js/vr-cube-sea.js"></script>
     <script src="js/vr-samples-util.js"></script>
@@ -111,7 +112,9 @@ found in the LICENSE file.
         var texture = textureLoader.loadTexture("media/textures/cube-sea.png");
         var cubeSea = new VRCubeSea(gl, texture);
 
-        var stats = new WGLUStats(gl);
+        var enablePerformanceMonitoring = WGLUUrl.getBool(
+            'enablePerformanceMonitoring', false);
+        var stats = new WGLUStats(gl, enablePerformanceMonitoring);
 
         function onAnimationFrame (t) {
           stats.begin();

--- a/samples/test-slow-render.html
+++ b/samples/test-slow-render.html
@@ -117,7 +117,9 @@ found in the LICENSE file.
         var textureLoader = new WGLUTextureLoader(gl);
         var texture = textureLoader.loadTexture("media/textures/cube-sea.png");
         cubeSea = new VRCubeSea(gl, texture, heavyGpu ? 12 : 10, heavyGpu);
-        stats = new WGLUStats(gl);
+        var enablePerformanceMonitoring = WGLUUrl.getBool(
+            'enablePerformanceMonitoring', false);
+        stats = new WGLUStats(gl, enablePerformanceMonitoring);
 
         // Wait until we have a WebGL context to resize and start rendering.
         window.addEventListener("resize", onResize, false);


### PR DESCRIPTION
Adds the enablePerformanceMonitoring URL parameter, which logs average and minimum FPS to the console once per second if enabled. Largely meant to be used for automated Daydream testing, but could be useful for other people, as well.