### PR TITLE
Set preserveDrawingBuffer to vrDisplay.capabilities.hasExternalDisplay

### DIFF
--- a/samples/05-room-scale.html
+++ b/samples/05-room-scale.html
@@ -188,7 +188,7 @@ found in the LICENSE file.
             vrDisplay.depthNear = 0.1;
             vrDisplay.depthFar = 1024.0;
 
-            initWebGL(true);
+            initWebGL(vrDisplay.capabilities.hasExternalDisplay);
 
             if (vrDisplay.stageParameters &&
                 vrDisplay.stageParameters.sizeX > 0 &&

--- a/samples/06-vr-audio.html
+++ b/samples/06-vr-audio.html
@@ -261,7 +261,7 @@ found in the LICENSE file.
             vrDisplay.depthNear = 0.1;
             vrDisplay.depthFar = 1024.0;
 
-            init(true);
+            init(vrDisplay.capabilities.hasExternalDisplay);
 
             VRSamplesUtil.addButton("Reset Pose", "R", null, function () { vrDisplay.resetPose(); });
 

--- a/samples/XX-vr-controllers.html
+++ b/samples/XX-vr-controllers.html
@@ -190,7 +190,7 @@ found in the LICENSE file.
             vrDisplay.depthNear = 0.1;
             vrDisplay.depthFar = 1024.0;
 
-            initWebGL(true);
+            initWebGL(vrDisplay.capabilities.hasExternalDisplay);
 
             if (vrDisplay.stageParameters &&
                 vrDisplay.stageParameters.sizeX > 0 &&


### PR DESCRIPTION
This wasn't being done consistently in all samples, causing problems
for mobile WebVR where this isn't supported well.