### PR TITLE
Add origin trial tokens for Chrome 59+

### DIFF
--- a/samples/00-hello-webvr.html
+++ b/samples/00-hello-webvr.html
@@ -13,6 +13,8 @@ found in the LICENSE file.
 
     <!-- Origin Trial Token, feature = WebVR, origin = https://webvr.info, expires = 2017-05-19 -->
     <meta http-equiv="origin-trial" data-feature="WebVR" data-expires="2017-05-19" content="Ah5/2/F7EZm/libHx65n+o1CLIE8omPGHx76AJe/eY+ewz2q4IpaPnMl4bcFU9sFSUv6MWnmHpTEc+jUmUawxAYAAABJeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSIiwiZXhwaXJ5IjoxNDk1MjAzMTM4fQ==">
+    <!-- Origin Trial Token, feature = WebVR (For Chrome M59+), origin = https://webvr.info, expires = 2017-06-16 -->
+    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M59+)" data-expires="2017-06-16" content="AqXaC8TXL8pGoJmSp5nVoNoBJNYt+oY/Wr42CyJElYoYKbr/bjxPx1SRbkvyMcSkFOMdXCH83F8RQr9Sm2IF0AQAAABfeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSMS4xIiwiZXhwaXJ5IjoxNDk3NjQxMzA4LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
 
     <title>00 - Hello WebVR!</title>
 

--- a/samples/01-vr-input.html
+++ b/samples/01-vr-input.html
@@ -13,6 +13,8 @@ found in the LICENSE file.
 
     <!-- Origin Trial Token, feature = WebVR, origin = https://webvr.info, expires = 2017-05-19 -->
     <meta http-equiv="origin-trial" data-feature="WebVR" data-expires="2017-05-19" content="Ah5/2/F7EZm/libHx65n+o1CLIE8omPGHx76AJe/eY+ewz2q4IpaPnMl4bcFU9sFSUv6MWnmHpTEc+jUmUawxAYAAABJeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSIiwiZXhwaXJ5IjoxNDk1MjAzMTM4fQ==">
+    <!-- Origin Trial Token, feature = WebVR (For Chrome M59+), origin = https://webvr.info, expires = 2017-06-16 -->
+    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M59+)" data-expires="2017-06-16" content="AqXaC8TXL8pGoJmSp5nVoNoBJNYt+oY/Wr42CyJElYoYKbr/bjxPx1SRbkvyMcSkFOMdXCH83F8RQr9Sm2IF0AQAAABfeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSMS4xIiwiZXhwaXJ5IjoxNDk3NjQxMzA4LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
 
     <title>01 - VR Input</title>
 

--- a/samples/02-stereo-rendering.html
+++ b/samples/02-stereo-rendering.html
@@ -12,6 +12,8 @@ found in the LICENSE file.
 
     <!-- Origin Trial Token, feature = WebVR, origin = https://webvr.info, expires = 2017-05-19 -->
     <meta http-equiv="origin-trial" data-feature="WebVR" data-expires="2017-05-19" content="Ah5/2/F7EZm/libHx65n+o1CLIE8omPGHx76AJe/eY+ewz2q4IpaPnMl4bcFU9sFSUv6MWnmHpTEc+jUmUawxAYAAABJeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSIiwiZXhwaXJ5IjoxNDk1MjAzMTM4fQ==">
+    <!-- Origin Trial Token, feature = WebVR (For Chrome M59+), origin = https://webvr.info, expires = 2017-06-16 -->
+    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M59+)" data-expires="2017-06-16" content="AqXaC8TXL8pGoJmSp5nVoNoBJNYt+oY/Wr42CyJElYoYKbr/bjxPx1SRbkvyMcSkFOMdXCH83F8RQr9Sm2IF0AQAAABfeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSMS4xIiwiZXhwaXJ5IjoxNDk3NjQxMzA4LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
 
     <title>02 - Stereo Rendering</title>
 

--- a/samples/03-vr-presentation.html
+++ b/samples/03-vr-presentation.html
@@ -13,6 +13,8 @@ found in the LICENSE file.
 
     <!-- Origin Trial Token, feature = WebVR, origin = https://webvr.info, expires = 2017-05-19 -->
     <meta http-equiv="origin-trial" data-feature="WebVR" data-expires="2017-05-19" content="Ah5/2/F7EZm/libHx65n+o1CLIE8omPGHx76AJe/eY+ewz2q4IpaPnMl4bcFU9sFSUv6MWnmHpTEc+jUmUawxAYAAABJeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSIiwiZXhwaXJ5IjoxNDk1MjAzMTM4fQ==">
+    <!-- Origin Trial Token, feature = WebVR (For Chrome M59+), origin = https://webvr.info, expires = 2017-06-16 -->
+    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M59+)" data-expires="2017-06-16" content="AqXaC8TXL8pGoJmSp5nVoNoBJNYt+oY/Wr42CyJElYoYKbr/bjxPx1SRbkvyMcSkFOMdXCH83F8RQr9Sm2IF0AQAAABfeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSMS4xIiwiZXhwaXJ5IjoxNDk3NjQxMzA4LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
 
     <title>03 - VR Presentation</title>
 

--- a/samples/04-simple-mirroring.html
+++ b/samples/04-simple-mirroring.html
@@ -13,6 +13,8 @@ found in the LICENSE file.
 
     <!-- Origin Trial Token, feature = WebVR, origin = https://webvr.info, expires = 2017-05-19 -->
     <meta http-equiv="origin-trial" data-feature="WebVR" data-expires="2017-05-19" content="Ah5/2/F7EZm/libHx65n+o1CLIE8omPGHx76AJe/eY+ewz2q4IpaPnMl4bcFU9sFSUv6MWnmHpTEc+jUmUawxAYAAABJeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSIiwiZXhwaXJ5IjoxNDk1MjAzMTM4fQ==">
+    <!-- Origin Trial Token, feature = WebVR (For Chrome M59+), origin = https://webvr.info, expires = 2017-06-16 -->
+    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M59+)" data-expires="2017-06-16" content="AqXaC8TXL8pGoJmSp5nVoNoBJNYt+oY/Wr42CyJElYoYKbr/bjxPx1SRbkvyMcSkFOMdXCH83F8RQr9Sm2IF0AQAAABfeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSMS4xIiwiZXhwaXJ5IjoxNDk3NjQxMzA4LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
 
     <title>04 - Simple Mirroring</title>
 

--- a/samples/04b-simple-mirroring-2.html
+++ b/samples/04b-simple-mirroring-2.html
@@ -13,6 +13,8 @@ found in the LICENSE file.
 
     <!-- Origin Trial Token, feature = WebVR, origin = https://webvr.info, expires = 2017-05-19 -->
     <meta http-equiv="origin-trial" data-feature="WebVR" data-expires="2017-05-19" content="Ah5/2/F7EZm/libHx65n+o1CLIE8omPGHx76AJe/eY+ewz2q4IpaPnMl4bcFU9sFSUv6MWnmHpTEc+jUmUawxAYAAABJeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSIiwiZXhwaXJ5IjoxNDk1MjAzMTM4fQ==">
+    <!-- Origin Trial Token, feature = WebVR (For Chrome M59+), origin = https://webvr.info, expires = 2017-06-16 -->
+    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M59+)" data-expires="2017-06-16" content="AqXaC8TXL8pGoJmSp5nVoNoBJNYt+oY/Wr42CyJElYoYKbr/bjxPx1SRbkvyMcSkFOMdXCH83F8RQr9Sm2IF0AQAAABfeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSMS4xIiwiZXhwaXJ5IjoxNDk3NjQxMzA4LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
 
     <title>04b - Simple Mirroring pt. 2</title>
 

--- a/samples/05-room-scale.html
+++ b/samples/05-room-scale.html
@@ -13,6 +13,8 @@ found in the LICENSE file.
 
     <!-- Origin Trial Token, feature = WebVR, origin = https://webvr.info, expires = 2017-05-19 -->
     <meta http-equiv="origin-trial" data-feature="WebVR" data-expires="2017-05-19" content="Ah5/2/F7EZm/libHx65n+o1CLIE8omPGHx76AJe/eY+ewz2q4IpaPnMl4bcFU9sFSUv6MWnmHpTEc+jUmUawxAYAAABJeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSIiwiZXhwaXJ5IjoxNDk1MjAzMTM4fQ==">
+    <!-- Origin Trial Token, feature = WebVR (For Chrome M59+), origin = https://webvr.info, expires = 2017-06-16 -->
+    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M59+)" data-expires="2017-06-16" content="AqXaC8TXL8pGoJmSp5nVoNoBJNYt+oY/Wr42CyJElYoYKbr/bjxPx1SRbkvyMcSkFOMdXCH83F8RQr9Sm2IF0AQAAABfeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSMS4xIiwiZXhwaXJ5IjoxNDk3NjQxMzA4LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
 
     <title>05 - Room Scale</title>
 

--- a/samples/06-vr-audio.html
+++ b/samples/06-vr-audio.html
@@ -13,6 +13,8 @@ found in the LICENSE file.
 
     <!-- Origin Trial Token, feature = WebVR, origin = https://webvr.info, expires = 2017-05-19 -->
     <meta http-equiv="origin-trial" data-feature="WebVR" data-expires="2017-05-19" content="Ah5/2/F7EZm/libHx65n+o1CLIE8omPGHx76AJe/eY+ewz2q4IpaPnMl4bcFU9sFSUv6MWnmHpTEc+jUmUawxAYAAABJeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSIiwiZXhwaXJ5IjoxNDk1MjAzMTM4fQ==">
+    <!-- Origin Trial Token, feature = WebVR (For Chrome M59+), origin = https://webvr.info, expires = 2017-06-16 -->
+    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M59+)" data-expires="2017-06-16" content="AqXaC8TXL8pGoJmSp5nVoNoBJNYt+oY/Wr42CyJElYoYKbr/bjxPx1SRbkvyMcSkFOMdXCH83F8RQr9Sm2IF0AQAAABfeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSMS4xIiwiZXhwaXJ5IjoxNDk3NjQxMzA4LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
 
     <title>06 - VR audio</title>
 

--- a/samples/07-advanced-mirroring.html
+++ b/samples/07-advanced-mirroring.html
@@ -13,6 +13,8 @@ found in the LICENSE file.
 
     <!-- Origin Trial Token, feature = WebVR, origin = https://webvr.info, expires = 2017-05-19 -->
     <meta http-equiv="origin-trial" data-feature="WebVR" data-expires="2017-05-19" content="Ah5/2/F7EZm/libHx65n+o1CLIE8omPGHx76AJe/eY+ewz2q4IpaPnMl4bcFU9sFSUv6MWnmHpTEc+jUmUawxAYAAABJeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSIiwiZXhwaXJ5IjoxNDk1MjAzMTM4fQ==">
+    <!-- Origin Trial Token, feature = WebVR (For Chrome M59+), origin = https://webvr.info, expires = 2017-06-16 -->
+    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M59+)" data-expires="2017-06-16" content="AqXaC8TXL8pGoJmSp5nVoNoBJNYt+oY/Wr42CyJElYoYKbr/bjxPx1SRbkvyMcSkFOMdXCH83F8RQr9Sm2IF0AQAAABfeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSMS4xIiwiZXhwaXJ5IjoxNDk3NjQxMzA4LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
 
     <title>07 - Advanced Mirroring</title>
 

--- a/samples/08-dynamic-resolution.html
+++ b/samples/08-dynamic-resolution.html
@@ -13,6 +13,8 @@ found in the LICENSE file.
 
     <!-- Origin Trial Token, feature = WebVR, origin = https://webvr.info, expires = 2017-05-19 -->
     <meta http-equiv="origin-trial" data-feature="WebVR" data-expires="2017-05-19" content="Ah5/2/F7EZm/libHx65n+o1CLIE8omPGHx76AJe/eY+ewz2q4IpaPnMl4bcFU9sFSUv6MWnmHpTEc+jUmUawxAYAAABJeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSIiwiZXhwaXJ5IjoxNDk1MjAzMTM4fQ==">
+    <!-- Origin Trial Token, feature = WebVR (For Chrome M59+), origin = https://webvr.info, expires = 2017-06-16 -->
+    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M59+)" data-expires="2017-06-16" content="AqXaC8TXL8pGoJmSp5nVoNoBJNYt+oY/Wr42CyJElYoYKbr/bjxPx1SRbkvyMcSkFOMdXCH83F8RQr9Sm2IF0AQAAABfeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSMS4xIiwiZXhwaXJ5IjoxNDk3NjQxMzA4LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
 
     <title>08 - Dynamic Resolution</title>
 

--- a/samples/XX-360-panorama.html
+++ b/samples/XX-360-panorama.html
@@ -13,6 +13,8 @@ found in the LICENSE file.
 
     <!-- Origin Trial Token, feature = WebVR, origin = https://webvr.info, expires = 2017-05-19 -->
     <meta http-equiv="origin-trial" data-feature="WebVR" data-expires="2017-05-19" content="Ah5/2/F7EZm/libHx65n+o1CLIE8omPGHx76AJe/eY+ewz2q4IpaPnMl4bcFU9sFSUv6MWnmHpTEc+jUmUawxAYAAABJeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSIiwiZXhwaXJ5IjoxNDk1MjAzMTM4fQ==">
+    <!-- Origin Trial Token, feature = WebVR (For Chrome M59+), origin = https://webvr.info, expires = 2017-06-16 -->
+    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M59+)" data-expires="2017-06-16" content="AqXaC8TXL8pGoJmSp5nVoNoBJNYt+oY/Wr42CyJElYoYKbr/bjxPx1SRbkvyMcSkFOMdXCH83F8RQr9Sm2IF0AQAAABfeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSMS4xIiwiZXhwaXJ5IjoxNDk3NjQxMzA4LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
 
     <title>XX - 360 Panorama</title>
 

--- a/samples/XX-vr-controllers.html
+++ b/samples/XX-vr-controllers.html
@@ -13,6 +13,8 @@ found in the LICENSE file.
 
     <!-- Origin Trial Token, feature = WebVR, origin = https://webvr.info, expires = 2017-05-19 -->
     <meta http-equiv="origin-trial" data-feature="WebVR" data-expires="2017-05-19" content="Ah5/2/F7EZm/libHx65n+o1CLIE8omPGHx76AJe/eY+ewz2q4IpaPnMl4bcFU9sFSUv6MWnmHpTEc+jUmUawxAYAAABJeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSIiwiZXhwaXJ5IjoxNDk1MjAzMTM4fQ==">
+    <!-- Origin Trial Token, feature = WebVR (For Chrome M59+), origin = https://webvr.info, expires = 2017-06-16 -->
+    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M59+)" data-expires="2017-06-16" content="AqXaC8TXL8pGoJmSp5nVoNoBJNYt+oY/Wr42CyJElYoYKbr/bjxPx1SRbkvyMcSkFOMdXCH83F8RQr9Sm2IF0AQAAABfeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSMS4xIiwiZXhwaXJ5IjoxNDk3NjQxMzA4LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
 
     <title>XX - VR Controllers</title>
 

--- a/samples/test-canvas-attributes.html
+++ b/samples/test-canvas-attributes.html
@@ -13,6 +13,8 @@ found in the LICENSE file.
 
     <!-- Origin Trial Token, feature = WebVR, origin = https://webvr.info, expires = 2017-05-19 -->
     <meta http-equiv="origin-trial" data-feature="WebVR" data-expires="2017-05-19" content="Ah5/2/F7EZm/libHx65n+o1CLIE8omPGHx76AJe/eY+ewz2q4IpaPnMl4bcFU9sFSUv6MWnmHpTEc+jUmUawxAYAAABJeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSIiwiZXhwaXJ5IjoxNDk1MjAzMTM4fQ==">
+    <!-- Origin Trial Token, feature = WebVR (For Chrome M59+), origin = https://webvr.info, expires = 2017-06-16 -->
+    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M59+)" data-expires="2017-06-16" content="AqXaC8TXL8pGoJmSp5nVoNoBJNYt+oY/Wr42CyJElYoYKbr/bjxPx1SRbkvyMcSkFOMdXCH83F8RQr9Sm2IF0AQAAABfeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSMS4xIiwiZXhwaXJ5IjoxNDk3NjQxMzA4LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
 
     <title>Canvas Attribute tests</title>
 

--- a/samples/test-slow-render.html
+++ b/samples/test-slow-render.html
@@ -13,6 +13,8 @@ found in the LICENSE file.
 
     <!-- Origin Trial Token, feature = WebVR, origin = https://webvr.info, expires = 2017-05-19 -->
     <meta http-equiv="origin-trial" data-feature="WebVR" data-expires="2017-05-19" content="Ah5/2/F7EZm/libHx65n+o1CLIE8omPGHx76AJe/eY+ewz2q4IpaPnMl4bcFU9sFSUv6MWnmHpTEc+jUmUawxAYAAABJeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSIiwiZXhwaXJ5IjoxNDk1MjAzMTM4fQ==">
+    <!-- Origin Trial Token, feature = WebVR (For Chrome M59+), origin = https://webvr.info, expires = 2017-06-16 -->
+    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M59+)" data-expires="2017-06-16" content="AqXaC8TXL8pGoJmSp5nVoNoBJNYt+oY/Wr42CyJElYoYKbr/bjxPx1SRbkvyMcSkFOMdXCH83F8RQr9Sm2IF0AQAAABfeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSMS4xIiwiZXhwaXJ5IjoxNDk3NjQxMzA4LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
 
     <title>TEST - Slow Rendering</title>
 

--- a/samples/test-vr-links.html
+++ b/samples/test-vr-links.html
@@ -11,8 +11,10 @@ found in the LICENSE file.
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
 
-    <!--Chrome origin trial header-->
-    <meta http-equiv="origin-trial" data-feature="WebVR" data-expires="2017-03-08" content="AiTLRl2auC8Te9Yue7upVEdZUgdgEDgrDIB9A1TO+Gkaz4BXn5TX/gZ0/MibV3+epWy39bW1MjbE+9giEGuICAcAAABJeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSIiwiZXhwaXJ5IjoxNDg4OTg2NjM0fQ==">
+    <!-- Origin Trial Token, feature = WebVR, origin = https://webvr.info, expires = 2017-05-19 -->
+    <meta http-equiv="origin-trial" data-feature="WebVR" data-expires="2017-05-19" content="Ah5/2/F7EZm/libHx65n+o1CLIE8omPGHx76AJe/eY+ewz2q4IpaPnMl4bcFU9sFSUv6MWnmHpTEc+jUmUawxAYAAABJeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSIiwiZXhwaXJ5IjoxNDk1MjAzMTM4fQ==">
+    <!-- Origin Trial Token, feature = WebVR (For Chrome M59+), origin = https://webvr.info, expires = 2017-06-16 -->
+    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M59+)" data-expires="2017-06-16" content="AqXaC8TXL8pGoJmSp5nVoNoBJNYt+oY/Wr42CyJElYoYKbr/bjxPx1SRbkvyMcSkFOMdXCH83F8RQr9Sm2IF0AQAAABfeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSMS4xIiwiZXhwaXJ5IjoxNDk3NjQxMzA4LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
 
     <title>TEST - VR Links</title>
 


### PR DESCRIPTION
Until the first trial expires there will be two tokens on each page.