### PR TITLE
Update WebVR origin trial tokens

### DIFF
--- a/samples/00-hello-webvr.html
+++ b/samples/00-hello-webvr.html
@@ -11,10 +11,8 @@ found in the LICENSE file.
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
 
-    <!-- Origin Trial Token, feature = WebVR, origin = https://webvr.info, expires = 2017-06-12 -->
-    <meta http-equiv="origin-trial" data-feature="WebVR" data-expires="2017-06-12" content="AprgitrgJaE/VsQcGMGfuB0GuBmVBNDr2z8MV3aP7CUONN+zDv0E46DVGXkSwc3SrnD3wRt9gTDTvk/PohsTsAwAAABJeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSIiwiZXhwaXJ5IjoxNDk3MzEyMDAwfQ==">
-    <!-- Origin Trial Token, feature = WebVR (For Chrome M59+), origin = https://webvr.info, expires = 2017-06-16 -->
-    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M59+)" data-expires="2017-06-16" content="AqXaC8TXL8pGoJmSp5nVoNoBJNYt+oY/Wr42CyJElYoYKbr/bjxPx1SRbkvyMcSkFOMdXCH83F8RQr9Sm2IF0AQAAABfeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSMS4xIiwiZXhwaXJ5IjoxNDk3NjQxMzA4LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
+    <!-- Origin Trial Token, feature = WebVR (For Chrome M59+), origin = https://webvr.info, expires = 2017-07-21 -->
+    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M59+)" data-expires="2017-07-21" content="AtJLsI9hT0/XyPU7DEDDxER7jyMU1oNeMk4diF9djsHCkwjulNzizKykf+CKW11B6+0ABoazxbd13jMxBvnUTQIAAABfeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSMS4xIiwiZXhwaXJ5IjoxNTAwNjc3MDE3LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
 
     <title>00 - Hello WebVR!</title>
 

--- a/samples/01-vr-input.html
+++ b/samples/01-vr-input.html
@@ -11,10 +11,8 @@ found in the LICENSE file.
     <meta name="mobile-web-app-capable" content="yes"> <!-- Launch fullscreen when added to home screen -->
     <meta name="apple-mobile-web-app-capable" content="yes"> <!-- Fullscreen Landscape on iOS -->
 
-    <!-- Origin Trial Token, feature = WebVR, origin = https://webvr.info, expires = 2017-06-12 -->
-    <meta http-equiv="origin-trial" data-feature="WebVR" data-expires="2017-06-12" content="AprgitrgJaE/VsQcGMGfuB0GuBmVBNDr2z8MV3aP7CUONN+zDv0E46DVGXkSwc3SrnD3wRt9gTDTvk/PohsTsAwAAABJeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSIiwiZXhwaXJ5IjoxNDk3MzEyMDAwfQ==">
-    <!-- Origin Trial Token, feature = WebVR (For Chrome M59+), origin = https://webvr.info, expires = 2017-06-16 -->
-    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M59+)" data-expires="2017-06-16" content="AqXaC8TXL8pGoJmSp5nVoNoBJNYt+oY/Wr42CyJElYoYKbr/bjxPx1SRbkvyMcSkFOMdXCH83F8RQr9Sm2IF0AQAAABfeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSMS4xIiwiZXhwaXJ5IjoxNDk3NjQxMzA4LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
+    <!-- Origin Trial Token, feature = WebVR (For Chrome M59+), origin = https://webvr.info, expires = 2017-07-21 -->
+    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M59+)" data-expires="2017-07-21" content="AtJLsI9hT0/XyPU7DEDDxER7jyMU1oNeMk4diF9djsHCkwjulNzizKykf+CKW11B6+0ABoazxbd13jMxBvnUTQIAAABfeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSMS4xIiwiZXhwaXJ5IjoxNTAwNjc3MDE3LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
 
     <title>01 - VR Input</title>
 

--- a/samples/02-stereo-rendering.html
+++ b/samples/02-stereo-rendering.html
@@ -10,10 +10,8 @@ found in the LICENSE file.
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes"> <!-- Fullscreen Landscape on iOS -->
 
-    <!-- Origin Trial Token, feature = WebVR, origin = https://webvr.info, expires = 2017-06-12 -->
-    <meta http-equiv="origin-trial" data-feature="WebVR" data-expires="2017-06-12" content="AprgitrgJaE/VsQcGMGfuB0GuBmVBNDr2z8MV3aP7CUONN+zDv0E46DVGXkSwc3SrnD3wRt9gTDTvk/PohsTsAwAAABJeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSIiwiZXhwaXJ5IjoxNDk3MzEyMDAwfQ==">
-    <!-- Origin Trial Token, feature = WebVR (For Chrome M59+), origin = https://webvr.info, expires = 2017-06-16 -->
-    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M59+)" data-expires="2017-06-16" content="AqXaC8TXL8pGoJmSp5nVoNoBJNYt+oY/Wr42CyJElYoYKbr/bjxPx1SRbkvyMcSkFOMdXCH83F8RQr9Sm2IF0AQAAABfeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSMS4xIiwiZXhwaXJ5IjoxNDk3NjQxMzA4LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
+    <!-- Origin Trial Token, feature = WebVR (For Chrome M59+), origin = https://webvr.info, expires = 2017-07-21 -->
+    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M59+)" data-expires="2017-07-21" content="AtJLsI9hT0/XyPU7DEDDxER7jyMU1oNeMk4diF9djsHCkwjulNzizKykf+CKW11B6+0ABoazxbd13jMxBvnUTQIAAABfeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSMS4xIiwiZXhwaXJ5IjoxNTAwNjc3MDE3LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
 
     <title>02 - Stereo Rendering</title>
 

--- a/samples/03-vr-presentation.html
+++ b/samples/03-vr-presentation.html
@@ -11,10 +11,8 @@ found in the LICENSE file.
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
 
-    <!-- Origin Trial Token, feature = WebVR, origin = https://webvr.info, expires = 2017-06-12 -->
-    <meta http-equiv="origin-trial" data-feature="WebVR" data-expires="2017-06-12" content="AprgitrgJaE/VsQcGMGfuB0GuBmVBNDr2z8MV3aP7CUONN+zDv0E46DVGXkSwc3SrnD3wRt9gTDTvk/PohsTsAwAAABJeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSIiwiZXhwaXJ5IjoxNDk3MzEyMDAwfQ==">
-    <!-- Origin Trial Token, feature = WebVR (For Chrome M59+), origin = https://webvr.info, expires = 2017-06-16 -->
-    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M59+)" data-expires="2017-06-16" content="AqXaC8TXL8pGoJmSp5nVoNoBJNYt+oY/Wr42CyJElYoYKbr/bjxPx1SRbkvyMcSkFOMdXCH83F8RQr9Sm2IF0AQAAABfeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSMS4xIiwiZXhwaXJ5IjoxNDk3NjQxMzA4LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
+    <!-- Origin Trial Token, feature = WebVR (For Chrome M59+), origin = https://webvr.info, expires = 2017-07-21 -->
+    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M59+)" data-expires="2017-07-21" content="AtJLsI9hT0/XyPU7DEDDxER7jyMU1oNeMk4diF9djsHCkwjulNzizKykf+CKW11B6+0ABoazxbd13jMxBvnUTQIAAABfeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSMS4xIiwiZXhwaXJ5IjoxNTAwNjc3MDE3LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
 
     <title>03 - VR Presentation</title>
 

--- a/samples/04-simple-mirroring.html
+++ b/samples/04-simple-mirroring.html
@@ -11,10 +11,8 @@ found in the LICENSE file.
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
 
-    <!-- Origin Trial Token, feature = WebVR, origin = https://webvr.info, expires = 2017-06-12 -->
-    <meta http-equiv="origin-trial" data-feature="WebVR" data-expires="2017-06-12" content="AprgitrgJaE/VsQcGMGfuB0GuBmVBNDr2z8MV3aP7CUONN+zDv0E46DVGXkSwc3SrnD3wRt9gTDTvk/PohsTsAwAAABJeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSIiwiZXhwaXJ5IjoxNDk3MzEyMDAwfQ==">
-    <!-- Origin Trial Token, feature = WebVR (For Chrome M59+), origin = https://webvr.info, expires = 2017-06-16 -->
-    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M59+)" data-expires="2017-06-16" content="AqXaC8TXL8pGoJmSp5nVoNoBJNYt+oY/Wr42CyJElYoYKbr/bjxPx1SRbkvyMcSkFOMdXCH83F8RQr9Sm2IF0AQAAABfeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSMS4xIiwiZXhwaXJ5IjoxNDk3NjQxMzA4LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
+    <!-- Origin Trial Token, feature = WebVR (For Chrome M59+), origin = https://webvr.info, expires = 2017-07-21 -->
+    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M59+)" data-expires="2017-07-21" content="AtJLsI9hT0/XyPU7DEDDxER7jyMU1oNeMk4diF9djsHCkwjulNzizKykf+CKW11B6+0ABoazxbd13jMxBvnUTQIAAABfeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSMS4xIiwiZXhwaXJ5IjoxNTAwNjc3MDE3LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
 
     <title>04 - Simple Mirroring</title>
 

--- a/samples/04b-simple-mirroring-2.html
+++ b/samples/04b-simple-mirroring-2.html
@@ -11,10 +11,8 @@ found in the LICENSE file.
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
 
-    <!-- Origin Trial Token, feature = WebVR, origin = https://webvr.info, expires = 2017-06-12 -->
-    <meta http-equiv="origin-trial" data-feature="WebVR" data-expires="2017-06-12" content="AprgitrgJaE/VsQcGMGfuB0GuBmVBNDr2z8MV3aP7CUONN+zDv0E46DVGXkSwc3SrnD3wRt9gTDTvk/PohsTsAwAAABJeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSIiwiZXhwaXJ5IjoxNDk3MzEyMDAwfQ==">
-    <!-- Origin Trial Token, feature = WebVR (For Chrome M59+), origin = https://webvr.info, expires = 2017-06-16 -->
-    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M59+)" data-expires="2017-06-16" content="AqXaC8TXL8pGoJmSp5nVoNoBJNYt+oY/Wr42CyJElYoYKbr/bjxPx1SRbkvyMcSkFOMdXCH83F8RQr9Sm2IF0AQAAABfeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSMS4xIiwiZXhwaXJ5IjoxNDk3NjQxMzA4LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
+    <!-- Origin Trial Token, feature = WebVR (For Chrome M59+), origin = https://webvr.info, expires = 2017-07-21 -->
+    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M59+)" data-expires="2017-07-21" content="AtJLsI9hT0/XyPU7DEDDxER7jyMU1oNeMk4diF9djsHCkwjulNzizKykf+CKW11B6+0ABoazxbd13jMxBvnUTQIAAABfeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSMS4xIiwiZXhwaXJ5IjoxNTAwNjc3MDE3LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
 
     <title>04b - Simple Mirroring pt. 2</title>
 

--- a/samples/05-room-scale.html
+++ b/samples/05-room-scale.html
@@ -11,10 +11,8 @@ found in the LICENSE file.
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
 
-    <!-- Origin Trial Token, feature = WebVR, origin = https://webvr.info, expires = 2017-06-12 -->
-    <meta http-equiv="origin-trial" data-feature="WebVR" data-expires="2017-06-12" content="AprgitrgJaE/VsQcGMGfuB0GuBmVBNDr2z8MV3aP7CUONN+zDv0E46DVGXkSwc3SrnD3wRt9gTDTvk/PohsTsAwAAABJeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSIiwiZXhwaXJ5IjoxNDk3MzEyMDAwfQ==">
-    <!-- Origin Trial Token, feature = WebVR (For Chrome M59+), origin = https://webvr.info, expires = 2017-06-16 -->
-    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M59+)" data-expires="2017-06-16" content="AqXaC8TXL8pGoJmSp5nVoNoBJNYt+oY/Wr42CyJElYoYKbr/bjxPx1SRbkvyMcSkFOMdXCH83F8RQr9Sm2IF0AQAAABfeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSMS4xIiwiZXhwaXJ5IjoxNDk3NjQxMzA4LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
+    <!-- Origin Trial Token, feature = WebVR (For Chrome M59+), origin = https://webvr.info, expires = 2017-07-21 -->
+    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M59+)" data-expires="2017-07-21" content="AtJLsI9hT0/XyPU7DEDDxER7jyMU1oNeMk4diF9djsHCkwjulNzizKykf+CKW11B6+0ABoazxbd13jMxBvnUTQIAAABfeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSMS4xIiwiZXhwaXJ5IjoxNTAwNjc3MDE3LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
 
     <title>05 - Room Scale</title>
 

--- a/samples/06-vr-audio.html
+++ b/samples/06-vr-audio.html
@@ -11,10 +11,8 @@ found in the LICENSE file.
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
 
-    <!-- Origin Trial Token, feature = WebVR, origin = https://webvr.info, expires = 2017-06-12 -->
-    <meta http-equiv="origin-trial" data-feature="WebVR" data-expires="2017-06-12" content="AprgitrgJaE/VsQcGMGfuB0GuBmVBNDr2z8MV3aP7CUONN+zDv0E46DVGXkSwc3SrnD3wRt9gTDTvk/PohsTsAwAAABJeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSIiwiZXhwaXJ5IjoxNDk3MzEyMDAwfQ==">
-    <!-- Origin Trial Token, feature = WebVR (For Chrome M59+), origin = https://webvr.info, expires = 2017-06-16 -->
-    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M59+)" data-expires="2017-06-16" content="AqXaC8TXL8pGoJmSp5nVoNoBJNYt+oY/Wr42CyJElYoYKbr/bjxPx1SRbkvyMcSkFOMdXCH83F8RQr9Sm2IF0AQAAABfeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSMS4xIiwiZXhwaXJ5IjoxNDk3NjQxMzA4LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
+    <!-- Origin Trial Token, feature = WebVR (For Chrome M59+), origin = https://webvr.info, expires = 2017-07-21 -->
+    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M59+)" data-expires="2017-07-21" content="AtJLsI9hT0/XyPU7DEDDxER7jyMU1oNeMk4diF9djsHCkwjulNzizKykf+CKW11B6+0ABoazxbd13jMxBvnUTQIAAABfeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSMS4xIiwiZXhwaXJ5IjoxNTAwNjc3MDE3LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
 
     <title>06 - VR audio</title>
 

--- a/samples/07-advanced-mirroring.html
+++ b/samples/07-advanced-mirroring.html
@@ -11,10 +11,8 @@ found in the LICENSE file.
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
 
-    <!-- Origin Trial Token, feature = WebVR, origin = https://webvr.info, expires = 2017-06-12 -->
-    <meta http-equiv="origin-trial" data-feature="WebVR" data-expires="2017-06-12" content="AprgitrgJaE/VsQcGMGfuB0GuBmVBNDr2z8MV3aP7CUONN+zDv0E46DVGXkSwc3SrnD3wRt9gTDTvk/PohsTsAwAAABJeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSIiwiZXhwaXJ5IjoxNDk3MzEyMDAwfQ==">
-    <!-- Origin Trial Token, feature = WebVR (For Chrome M59+), origin = https://webvr.info, expires = 2017-06-16 -->
-    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M59+)" data-expires="2017-06-16" content="AqXaC8TXL8pGoJmSp5nVoNoBJNYt+oY/Wr42CyJElYoYKbr/bjxPx1SRbkvyMcSkFOMdXCH83F8RQr9Sm2IF0AQAAABfeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSMS4xIiwiZXhwaXJ5IjoxNDk3NjQxMzA4LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
+    <!-- Origin Trial Token, feature = WebVR (For Chrome M59+), origin = https://webvr.info, expires = 2017-07-21 -->
+    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M59+)" data-expires="2017-07-21" content="AtJLsI9hT0/XyPU7DEDDxER7jyMU1oNeMk4diF9djsHCkwjulNzizKykf+CKW11B6+0ABoazxbd13jMxBvnUTQIAAABfeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSMS4xIiwiZXhwaXJ5IjoxNTAwNjc3MDE3LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
 
     <title>07 - Advanced Mirroring</title>
 

--- a/samples/08-dynamic-resolution.html
+++ b/samples/08-dynamic-resolution.html
@@ -11,10 +11,8 @@ found in the LICENSE file.
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
 
-    <!-- Origin Trial Token, feature = WebVR, origin = https://webvr.info, expires = 2017-06-12 -->
-    <meta http-equiv="origin-trial" data-feature="WebVR" data-expires="2017-06-12" content="AprgitrgJaE/VsQcGMGfuB0GuBmVBNDr2z8MV3aP7CUONN+zDv0E46DVGXkSwc3SrnD3wRt9gTDTvk/PohsTsAwAAABJeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSIiwiZXhwaXJ5IjoxNDk3MzEyMDAwfQ==">
-    <!-- Origin Trial Token, feature = WebVR (For Chrome M59+), origin = https://webvr.info, expires = 2017-06-16 -->
-    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M59+)" data-expires="2017-06-16" content="AqXaC8TXL8pGoJmSp5nVoNoBJNYt+oY/Wr42CyJElYoYKbr/bjxPx1SRbkvyMcSkFOMdXCH83F8RQr9Sm2IF0AQAAABfeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSMS4xIiwiZXhwaXJ5IjoxNDk3NjQxMzA4LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
+    <!-- Origin Trial Token, feature = WebVR (For Chrome M59+), origin = https://webvr.info, expires = 2017-07-21 -->
+    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M59+)" data-expires="2017-07-21" content="AtJLsI9hT0/XyPU7DEDDxER7jyMU1oNeMk4diF9djsHCkwjulNzizKykf+CKW11B6+0ABoazxbd13jMxBvnUTQIAAABfeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSMS4xIiwiZXhwaXJ5IjoxNTAwNjc3MDE3LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
 
     <title>08 - Dynamic Resolution</title>
 

--- a/samples/XX-360-panorama.html
+++ b/samples/XX-360-panorama.html
@@ -11,10 +11,8 @@ found in the LICENSE file.
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
 
-    <!-- Origin Trial Token, feature = WebVR, origin = https://webvr.info, expires = 2017-06-12 -->
-    <meta http-equiv="origin-trial" data-feature="WebVR" data-expires="2017-06-12" content="AprgitrgJaE/VsQcGMGfuB0GuBmVBNDr2z8MV3aP7CUONN+zDv0E46DVGXkSwc3SrnD3wRt9gTDTvk/PohsTsAwAAABJeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSIiwiZXhwaXJ5IjoxNDk3MzEyMDAwfQ==">
-    <!-- Origin Trial Token, feature = WebVR (For Chrome M59+), origin = https://webvr.info, expires = 2017-06-16 -->
-    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M59+)" data-expires="2017-06-16" content="AqXaC8TXL8pGoJmSp5nVoNoBJNYt+oY/Wr42CyJElYoYKbr/bjxPx1SRbkvyMcSkFOMdXCH83F8RQr9Sm2IF0AQAAABfeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSMS4xIiwiZXhwaXJ5IjoxNDk3NjQxMzA4LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
+    <!-- Origin Trial Token, feature = WebVR (For Chrome M59+), origin = https://webvr.info, expires = 2017-07-21 -->
+    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M59+)" data-expires="2017-07-21" content="AtJLsI9hT0/XyPU7DEDDxER7jyMU1oNeMk4diF9djsHCkwjulNzizKykf+CKW11B6+0ABoazxbd13jMxBvnUTQIAAABfeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSMS4xIiwiZXhwaXJ5IjoxNTAwNjc3MDE3LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
 
     <title>XX - 360 Panorama</title>
 

--- a/samples/XX-360-video.html
+++ b/samples/XX-360-video.html
@@ -11,10 +11,8 @@ found in the LICENSE file.
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
 
-    <!-- Origin Trial Token, feature = WebVR, origin = https://webvr.info, expires = 2017-06-12 -->
-    <meta http-equiv="origin-trial" data-feature="WebVR" data-expires="2017-06-12" content="AprgitrgJaE/VsQcGMGfuB0GuBmVBNDr2z8MV3aP7CUONN+zDv0E46DVGXkSwc3SrnD3wRt9gTDTvk/PohsTsAwAAABJeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSIiwiZXhwaXJ5IjoxNDk3MzEyMDAwfQ==">
-    <!-- Origin Trial Token, feature = WebVR (For Chrome M59+), origin = https://webvr.info, expires = 2017-06-16 -->
-    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M59+)" data-expires="2017-06-16" content="AqXaC8TXL8pGoJmSp5nVoNoBJNYt+oY/Wr42CyJElYoYKbr/bjxPx1SRbkvyMcSkFOMdXCH83F8RQr9Sm2IF0AQAAABfeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSMS4xIiwiZXhwaXJ5IjoxNDk3NjQxMzA4LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
+    <!-- Origin Trial Token, feature = WebVR (For Chrome M59+), origin = https://webvr.info, expires = 2017-07-21 -->
+    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M59+)" data-expires="2017-07-21" content="AtJLsI9hT0/XyPU7DEDDxER7jyMU1oNeMk4diF9djsHCkwjulNzizKykf+CKW11B6+0ABoazxbd13jMxBvnUTQIAAABfeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSMS4xIiwiZXhwaXJ5IjoxNTAwNjc3MDE3LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
 
     <title>XX - 360 Video</title>
 

--- a/samples/XX-vr-controllers.html
+++ b/samples/XX-vr-controllers.html
@@ -11,10 +11,8 @@ found in the LICENSE file.
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
 
-    <!-- Origin Trial Token, feature = WebVR, origin = https://webvr.info, expires = 2017-06-12 -->
-    <meta http-equiv="origin-trial" data-feature="WebVR" data-expires="2017-06-12" content="AprgitrgJaE/VsQcGMGfuB0GuBmVBNDr2z8MV3aP7CUONN+zDv0E46DVGXkSwc3SrnD3wRt9gTDTvk/PohsTsAwAAABJeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSIiwiZXhwaXJ5IjoxNDk3MzEyMDAwfQ==">
-    <!-- Origin Trial Token, feature = WebVR (For Chrome M59+), origin = https://webvr.info, expires = 2017-06-16 -->
-    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M59+)" data-expires="2017-06-16" content="AqXaC8TXL8pGoJmSp5nVoNoBJNYt+oY/Wr42CyJElYoYKbr/bjxPx1SRbkvyMcSkFOMdXCH83F8RQr9Sm2IF0AQAAABfeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSMS4xIiwiZXhwaXJ5IjoxNDk3NjQxMzA4LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
+    <!-- Origin Trial Token, feature = WebVR (For Chrome M59+), origin = https://webvr.info, expires = 2017-07-21 -->
+    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M59+)" data-expires="2017-07-21" content="AtJLsI9hT0/XyPU7DEDDxER7jyMU1oNeMk4diF9djsHCkwjulNzizKykf+CKW11B6+0ABoazxbd13jMxBvnUTQIAAABfeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSMS4xIiwiZXhwaXJ5IjoxNTAwNjc3MDE3LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
 
     <title>XX - VR Controllers</title>
 

--- a/samples/test-canvas-attributes.html
+++ b/samples/test-canvas-attributes.html
@@ -11,10 +11,8 @@ found in the LICENSE file.
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
 
-    <!-- Origin Trial Token, feature = WebVR, origin = https://webvr.info, expires = 2017-06-12 -->
-    <meta http-equiv="origin-trial" data-feature="WebVR" data-expires="2017-06-12" content="AprgitrgJaE/VsQcGMGfuB0GuBmVBNDr2z8MV3aP7CUONN+zDv0E46DVGXkSwc3SrnD3wRt9gTDTvk/PohsTsAwAAABJeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSIiwiZXhwaXJ5IjoxNDk3MzEyMDAwfQ==">
-    <!-- Origin Trial Token, feature = WebVR (For Chrome M59+), origin = https://webvr.info, expires = 2017-06-16 -->
-    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M59+)" data-expires="2017-06-16" content="AqXaC8TXL8pGoJmSp5nVoNoBJNYt+oY/Wr42CyJElYoYKbr/bjxPx1SRbkvyMcSkFOMdXCH83F8RQr9Sm2IF0AQAAABfeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSMS4xIiwiZXhwaXJ5IjoxNDk3NjQxMzA4LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
+    <!-- Origin Trial Token, feature = WebVR (For Chrome M59+), origin = https://webvr.info, expires = 2017-07-21 -->
+    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M59+)" data-expires="2017-07-21" content="AtJLsI9hT0/XyPU7DEDDxER7jyMU1oNeMk4diF9djsHCkwjulNzizKykf+CKW11B6+0ABoazxbd13jMxBvnUTQIAAABfeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSMS4xIiwiZXhwaXJ5IjoxNTAwNjc3MDE3LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
 
     <title>Canvas Attribute tests</title>
 

--- a/samples/test-slow-render.html
+++ b/samples/test-slow-render.html
@@ -11,10 +11,8 @@ found in the LICENSE file.
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
 
-    <!-- Origin Trial Token, feature = WebVR, origin = https://webvr.info, expires = 2017-06-12 -->
-    <meta http-equiv="origin-trial" data-feature="WebVR" data-expires="2017-06-12" content="AprgitrgJaE/VsQcGMGfuB0GuBmVBNDr2z8MV3aP7CUONN+zDv0E46DVGXkSwc3SrnD3wRt9gTDTvk/PohsTsAwAAABJeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSIiwiZXhwaXJ5IjoxNDk3MzEyMDAwfQ==">
-    <!-- Origin Trial Token, feature = WebVR (For Chrome M59+), origin = https://webvr.info, expires = 2017-06-16 -->
-    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M59+)" data-expires="2017-06-16" content="AqXaC8TXL8pGoJmSp5nVoNoBJNYt+oY/Wr42CyJElYoYKbr/bjxPx1SRbkvyMcSkFOMdXCH83F8RQr9Sm2IF0AQAAABfeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSMS4xIiwiZXhwaXJ5IjoxNDk3NjQxMzA4LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
+    <!-- Origin Trial Token, feature = WebVR (For Chrome M59+), origin = https://webvr.info, expires = 2017-07-21 -->
+    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M59+)" data-expires="2017-07-21" content="AtJLsI9hT0/XyPU7DEDDxER7jyMU1oNeMk4diF9djsHCkwjulNzizKykf+CKW11B6+0ABoazxbd13jMxBvnUTQIAAABfeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSMS4xIiwiZXhwaXJ5IjoxNTAwNjc3MDE3LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
 
     <title>TEST - Slow Rendering</title>
 

--- a/samples/test-vr-links.html
+++ b/samples/test-vr-links.html
@@ -11,10 +11,8 @@ found in the LICENSE file.
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
 
-    <!-- Origin Trial Token, feature = WebVR, origin = https://webvr.info, expires = 2017-06-12 -->
-    <meta http-equiv="origin-trial" data-feature="WebVR" data-expires="2017-06-12" content="AprgitrgJaE/VsQcGMGfuB0GuBmVBNDr2z8MV3aP7CUONN+zDv0E46DVGXkSwc3SrnD3wRt9gTDTvk/PohsTsAwAAABJeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSIiwiZXhwaXJ5IjoxNDk3MzEyMDAwfQ==">
-    <!-- Origin Trial Token, feature = WebVR (For Chrome M59+), origin = https://webvr.info, expires = 2017-06-16 -->
-    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M59+)" data-expires="2017-06-16" content="AqXaC8TXL8pGoJmSp5nVoNoBJNYt+oY/Wr42CyJElYoYKbr/bjxPx1SRbkvyMcSkFOMdXCH83F8RQr9Sm2IF0AQAAABfeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSMS4xIiwiZXhwaXJ5IjoxNDk3NjQxMzA4LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
+    <!-- Origin Trial Token, feature = WebVR (For Chrome M59+), origin = https://webvr.info, expires = 2017-07-21 -->
+    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M59+)" data-expires="2017-07-21" content="AtJLsI9hT0/XyPU7DEDDxER7jyMU1oNeMk4diF9djsHCkwjulNzizKykf+CKW11B6+0ABoazxbd13jMxBvnUTQIAAABfeyJvcmlnaW4iOiJodHRwczovL3dlYnZyLmluZm86NDQzIiwiZmVhdHVyZSI6IldlYlZSMS4xIiwiZXhwaXJ5IjoxNTAwNjc3MDE3LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
 
     <title>TEST - VR Links</title>
 


### PR DESCRIPTION
This updates the 59+ trial token and removes the old trial token as 59 is now stable.