### PR TITLE
Added a license to the entire repo.

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,27 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
**TL;DR: If you have contributed to the webvr.info repository please respond in this pull request that you consent to have the standard Chromium license applied.**

It's been pointed out that (due to some quirks of how this repo came to be and my own inattentiveness) the top level of the repo does not have a proper license file. (The samples directory does, primarily because it started life as a separate repo.) I'd like that correct that so that we can make easier use of the full repo in things like test environments. As such, this pull request will apply the same standard Chromium license that was already applied to the samples directory to the entire repository.

Given the somewhat touchy nature of licensing things, however, I'm reaching out to anyone who has previously contributed to the non-samples portion of the repo to get written consent that you're OK with having the license applied. If not we will have to remove and replace your contributions. Sorry!

Thanks for everyone's help, and sorry for the inconvenience.

Need written consent from:
@mkeblx, @HalfdanJ, @cvan, @peterood, @willeastcott, @poshaughnessy, @ngokevin, @leweaver, @kschzt, @brianpeiris, @anssiko 

And for the record, I consent to this change as well. :)