### PR TITLE
Add standardSize URL args to force 1024x1024 per eye

### DIFF
--- a/samples/index.html
+++ b/samples/index.html
@@ -111,9 +111,9 @@
 
             // Tests
             { index: "Test", path: "test-canvas-attributes.html", title: "Canvas Attributes" },
-            { index: "Test", path: "test-slow-render.html?heavyGpu=1", title: "Slow GPU" },
-            { index: "Test", path: "test-slow-render.html?workTime=48", title: "Slow Javascript" },
-            { index: "Test", path: "test-slow-render.html?heavyGpu=1&workTime=48", title: "Slow GPU and Javascript" },
+            { index: "Test", path: "test-slow-render.html?heavyGpu=1&cubeScale=0.3&standardSize=true&renderScale=1.0", title: "Slow GPU" },
+            { index: "Test", path: "test-slow-render.html?workTime=12&standardSize=true&renderScale=1.0", title: "Slow Javascript" },
+            { index: "Test", path: "test-slow-render.html?heavyGpu=1&cubeScale=0.3&workTime=12&standardSize=true&renderScale=1.0", title: "Slow GPU and Javascript" },
             { index: "Test", path: "03-vr-presentation.html?webgl2=1", title: "WebGL 2" },
             { index: "Test", path: "test-vr-links.html", title: "VR Links" },
             { index: "Test", path: "insecure/test-insecure.html", title: "Insecure WebVR", insecure: true },

--- a/samples/test-slow-render.html
+++ b/samples/test-slow-render.html
@@ -88,6 +88,7 @@ found in the LICENSE file.
       var cubeCount = WGLUUrl.getInt('cubeCount', heavyGpu ? 12 : 10);
       var cubeScale = WGLUUrl.getFloat('cubeScale', 1.0);
       var simulatedWorkTimeMs = WGLUUrl.getFloat('workTime', 0);
+      var standardSize = WGLUUrl.getBool('standardSize', false);
       var renderScale = WGLUUrl.getFloat('renderScale', 1.0);
       var latencyPatch = WGLUUrl.getBool('latencyPatch', false);
 
@@ -207,8 +208,14 @@ found in the LICENSE file.
           var leftEye = vrDisplay.getEyeParameters("left");
           var rightEye = vrDisplay.getEyeParameters("right");
 
-          webglCanvas.width = Math.max(leftEye.renderWidth, rightEye.renderWidth) * 2 * renderScale;
-          webglCanvas.height = Math.max(leftEye.renderHeight, rightEye.renderHeight) * renderScale;
+          // If user has specified renderWidth/Height in URL, use that instead of the
+          // recommended resolution. Useful for testing to get cross-device comparable
+          // results. This still gets multiplied by renderScale if that is set.
+          var renderWidth = standardSize ? 1024 : Math.max(leftEye.renderWidth, rightEye.renderWidth);
+          var renderHeight = standardSize ? 1024 : Math.max(leftEye.renderHeight, rightEye.renderHeight);
+
+          webglCanvas.width = renderWidth * 2 * renderScale;
+          webglCanvas.height = renderHeight * renderScale;
         } else {
           webglCanvas.width = webglCanvas.offsetWidth * window.devicePixelRatio;
           webglCanvas.height = webglCanvas.offsetHeight * window.devicePixelRatio;


### PR DESCRIPTION
This is useful for tests to get comparable results across different devices or
varying HMDs where the recommended resolution may differ. Update the samples
index page to use this, and also use more reasonable example parameters that
make it possible to reach 60fps on slower hardware such as mobile.

Also uploaded to a local fork for testing: https://klausw.github.io/webvr.info/samples/