### PR TITLE
Updated samples to handle pointerrestricted and context loss events…

### DIFF
--- a/samples/00-hello-webvr.html
+++ b/samples/00-hello-webvr.html
@@ -197,6 +197,8 @@ found in the LICENSE file.
           for (var i = 0; i < displays.length; ++i) {
             document.body.appendChild(buildVRElement(displays[i]));
           }
+        }, function () {
+          VRSamplesUtil.addError("Your browser does not support WebVR. See <a href='http://webvr.info'>webvr.info</a> for assistance.");
         });
 
         window.addEventListener("vrdisplayconnect", eventFired, false);

--- a/samples/01-vr-input.html
+++ b/samples/01-vr-input.html
@@ -160,6 +160,8 @@ found in the LICENSE file.
           } else {
             VRSamplesUtil.addInfo("WebVR supported, but no VRDisplays found.", 3000);
           }
+        }, function () {
+          VRSamplesUtil.addError("Your browser does not support WebVR. See <a href='http://webvr.info'>webvr.info</a> for assistance.");
         });
       } else if (navigator.getVRDevices) {
         VRSamplesUtil.addError("Your browser supports WebVR but not the latest version. See <a href='http://webvr.info'>webvr.info</a> for more info.");

--- a/samples/02-stereo-rendering.html
+++ b/samples/02-stereo-rendering.html
@@ -133,6 +133,8 @@ found in the LICENSE file.
           } else {
             VRSamplesUtil.addInfo("WebVR supported, but no VRDisplays found.", 3000);
           }
+        }, function () {
+          VRSamplesUtil.addError("Your browser does not support WebVR. See <a href='http://webvr.info'>webvr.info</a> for assistance.");
         });
       } else if (navigator.getVRDevices) {
         VRSamplesUtil.addError("Your browser supports WebVR but not the latest version. See <a href='http://webvr.info'>webvr.info</a> for more info.");

--- a/samples/03-vr-presentation.html
+++ b/samples/03-vr-presentation.html
@@ -97,42 +97,70 @@ found in the LICENSE file.
       var viewMat = mat4.create();
 
       var vrPresentButton = null;
+      var presentingMessage = document.getElementById("presenting-message");
 
       // ===================================================
       // WebGL scene setup. This code is not WebVR specific.
       // ===================================================
 
       // WebGL setup.
-      var webglCanvas = document.getElementById("webgl-canvas");
-      var glAttribs = {
-        alpha: false,
-      };
-      var useWebgl2 = WGLUUrl.getBool('webgl2', false);
-      var contextTypes = useWebgl2 ? ["webgl2"] : ["webgl", "experimental-webgl"];
       var gl = null;
-      for (var i in contextTypes) {
-        gl = webglCanvas.getContext(contextTypes[i], glAttribs);
-        if (gl)
-          break;
+      var cubeSea = null;
+      var stats = null;
+
+      function onContextLost( event ) {
+        event.preventDefault();
+        console.log( 'WebGL Context Lost.' );
+        gl = null;
+        cubeSea = null;
+        stats = null;
       }
-      if (!gl) {
-        var webglType = (useWebgl2 ? "WebGL 2" : "WebGL")
-        VRSamplesUtil.addError("Your browser does not support " + webglType + ".");
-        return;
+
+      function onContextRestored( event ) {
+        console.log( 'WebGL Context Restored.' );
+        initWebGL();
       }
-      gl.clearColor(0.1, 0.2, 0.3, 1.0);
-      gl.enable(gl.DEPTH_TEST);
-      gl.enable(gl.CULL_FACE);
 
-      var textureLoader = new WGLUTextureLoader(gl);
-      var texture = textureLoader.loadTexture("media/textures/cube-sea.png");
-      var cubeSea = new VRCubeSea(gl, texture);
+      var webglCanvas = document.getElementById("webgl-canvas");
+      webglCanvas.addEventListener( 'webglcontextlost', onContextLost, false );
+      webglCanvas.addEventListener( 'webglcontextrestored', onContextRestored, false );
 
-      var enablePerformanceMonitoring = WGLUUrl.getBool(
-          'enablePerformanceMonitoring', false);
-      var stats = new WGLUStats(gl, enablePerformanceMonitoring);
+      function initWebGL() {
+        var glAttribs = {
+          alpha: false,
+        };
+        var useWebgl2 = WGLUUrl.getBool('webgl2', false);
+        var contextTypes = useWebgl2 ? ["webgl2"] : ["webgl", "experimental-webgl"];
 
-      var presentingMessage = document.getElementById("presenting-message");
+        for (var i in contextTypes) {
+          gl = webglCanvas.getContext(contextTypes[i], glAttribs);
+          if (gl)
+            break;
+        }
+        if (!gl) {
+          var webglType = (useWebgl2 ? "WebGL 2" : "WebGL")
+          VRSamplesUtil.addError("Your browser does not support " + webglType + ".");
+          return;
+        }
+        gl.clearColor(0.1, 0.2, 0.3, 1.0);
+        gl.enable(gl.DEPTH_TEST);
+        gl.enable(gl.CULL_FACE);
+
+        var textureLoader = new WGLUTextureLoader(gl);
+        var texture = textureLoader.loadTexture("media/textures/cube-sea.png");
+        cubeSea = new VRCubeSea(gl, texture);
+
+        var enablePerformanceMonitoring = WGLUUrl.getBool(
+            'enablePerformanceMonitoring', false);
+        stats = new WGLUStats(gl, enablePerformanceMonitoring);
+
+        // Wait until we have a WebGL context to resize and start rendering.
+        window.addEventListener("resize", onResize, false);
+        onResize();
+        window.requestAnimationFrame(onAnimationFrame);
+      }
+      initWebGL();
+
 
       // ================================
       // WebVR-specific code begins here.
@@ -237,6 +265,8 @@ found in the LICENSE file.
           } else {
             VRSamplesUtil.addInfo("WebVR supported, but no VRDisplays found.", 3000);
           }
+        }, function () {
+          VRSamplesUtil.addError("Your browser does not support WebVR. See <a href='http://webvr.info'>webvr.info</a> for assistance.");
         });
       } else if (navigator.getVRDevices) {
         VRSamplesUtil.addError("Your browser supports WebVR but not the latest version. See <a href='http://webvr.info'>webvr.info</a> for more info.");
@@ -265,8 +295,6 @@ found in the LICENSE file.
           webglCanvas.height = webglCanvas.offsetHeight * window.devicePixelRatio;
         }
       }
-      window.addEventListener("resize", onResize, false);
-      onResize();
 
       // Listen for click events on the canvas, which may come from something
       // like a Cardboard viewer or other VR controller, and make a small change
@@ -275,14 +303,41 @@ found in the LICENSE file.
       // should ideally always be minimally supported.
       function onClick () {
         // Reset the background color to a random value
-        gl.clearColor(
+        if (gl) {
+          gl.clearColor(
             Math.random() * 0.5,
             Math.random() * 0.5,
             Math.random() * 0.5, 1.0);
+        }
       }
+
+      // Register for mouse restricted events while in VR
+      // (e.g. mouse no longer available on desktop 2D view)
+      function onDisplayPointerRestricted() {
+        if (webglCanvas && webglCanvas.requestPointerLock) {
+          webglCanvas.requestPointerLock();
+        }
+      }
+
+      // Register for mouse unrestricted events while in VR
+      // (e.g. mouse once again available on desktop 2D view)
+      function onDisplayPointerUnrestricted() {
+        var lock = document.pointerLockElement;
+        if (lock && lock === webglCanvas && document.exitPointerLock) {
+          document.exitPointerLock();
+        }
+      }
+      
       webglCanvas.addEventListener("click", onClick, false);
+      window.addEventListener('vrdisplaypointerrestricted', onDisplayPointerRestricted);
+      window.addEventListener('vrdisplaypointerunrestricted', onDisplayPointerUnrestricted);
 
       function onAnimationFrame (t) {
+        // do not attempt to render if there is no available WebGL context
+        if (!gl || !stats || !cubeSea) {
+          return;
+        }
+
         stats.begin();
 
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);

--- a/samples/04-simple-mirroring.html
+++ b/samples/04-simple-mirroring.html
@@ -89,10 +89,26 @@ found in the LICENSE file.
       // ================================
 
       // WebGL setup.
-      var webglCanvas = document.getElementById("webgl-canvas");
       var gl = null;
       var cubeSea = null;
       var stats = null;
+
+      function onContextLost( event ) {
+        event.preventDefault();
+        console.log( 'WebGL Context Lost.' );
+        gl = null;
+        cubeSea = null;
+        stats = null;
+      }
+
+      function onContextRestored( event ) {
+        console.log( 'WebGL Context Restored.' );
+        initWebGL(vrDisplay ? vrDisplay.capabilities.hasExternalDisplay : false);
+      }
+
+      var webglCanvas = document.getElementById("webgl-canvas");
+      webglCanvas.addEventListener( 'webglcontextlost', onContextLost, false );
+      webglCanvas.addEventListener( 'webglcontextrestored', onContextRestored, false );
 
       function initWebGL (preserveDrawingBuffer) {
         // Setting preserveDrawingBuffer to true prevents the canvas from being
@@ -202,6 +218,8 @@ found in the LICENSE file.
             initWebGL(false);
             VRSamplesUtil.addInfo("WebVR supported, but no VRDisplays found.", 3000);
           }
+        }, function () {
+          VRSamplesUtil.addError("Your browser does not support WebVR. See <a href='http://webvr.info'>webvr.info</a> for assistance.");
         });
       } else if (navigator.getVRDevices) {
         initWebGL(false);
@@ -236,6 +254,11 @@ found in the LICENSE file.
       }
 
       function onAnimationFrame (t) {
+        // do not attempt to render if there is no available WebGL context
+        if (!gl || !stats || !cubeSea) {
+          return;
+        }
+
         stats.begin();
 
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);

--- a/samples/04b-simple-mirroring-2.html
+++ b/samples/04b-simple-mirroring-2.html
@@ -112,11 +112,28 @@ found in the LICENSE file.
       // ================================
 
       // WebGL setup.
-      var webglCanvas = document.getElementById("webgl-canvas");
-      var canvasClip = document.getElementById("canvas-clip");
       var gl = null;
       var cubeSea = null;
       var stats = null;
+
+      function onContextLost( event ) {
+        event.preventDefault();
+        console.log( 'WebGL Context Lost.' );
+        gl = null;
+        cubeSea = null;
+        stats = null;
+      }
+
+      function onContextRestored( event ) {
+        console.log( 'WebGL Context Restored.' );
+        initWebGL(vrDisplay ? vrDisplay.capabilities.hasExternalDisplay : false);
+      }
+
+      var webglCanvas = document.getElementById("webgl-canvas");
+      webglCanvas.addEventListener( 'webglcontextlost', onContextLost, false );
+      webglCanvas.addEventListener( 'webglcontextrestored', onContextRestored, false );
+
+      var canvasClip = document.getElementById("canvas-clip");
 
       function initWebGL (preserveDrawingBuffer) {
         var glAttribs = {
@@ -226,6 +243,8 @@ found in the LICENSE file.
             initWebGL(false);
             VRSamplesUtil.addInfo("WebVR supported, but no VRDisplays found.", 3000);
           }
+        }, function () {
+          VRSamplesUtil.addError("Your browser does not support WebVR. See <a href='http://webvr.info'>webvr.info</a> for assistance.");
         });
       } else if (navigator.getVRDevices) {
         initWebGL(false);
@@ -250,14 +269,41 @@ found in the LICENSE file.
 
       function onClick () {
         // Reset the background color to a random value
-        gl.clearColor(
+        if (gl) {
+          gl.clearColor(
             Math.random() * 0.5,
             Math.random() * 0.5,
             Math.random() * 0.5, 1.0);
+        }
       }
+
+      // Register for mouse restricted events while in VR
+      // (e.g. mouse no longer available on desktop 2D view)
+      function onDisplayPointerRestricted() {
+        if (webglCanvas && webglCanvas.requestPointerLock) {
+          webglCanvas.requestPointerLock();
+        }
+      }
+
+      // Register for mouse unrestricted events while in VR
+      // (e.g. mouse once again available on desktop 2D view)
+      function onDisplayPointerUnrestricted() {
+        var lock = document.pointerLockElement;
+        if (lock && lock === webglCanvas && document.exitPointerLock) {
+          document.exitPointerLock();
+        }
+      }
+
       webglCanvas.addEventListener("click", onClick, false);
+      window.addEventListener('vrdisplaypointerrestricted', onDisplayPointerRestricted);
+      window.addEventListener('vrdisplaypointerunrestricted', onDisplayPointerUnrestricted);
 
       function onAnimationFrame (t) {
+        // do not attempt to render if there is no available WebGL context
+        if (!gl || !stats || !cubeSea) {
+          return;
+        }
+
         stats.begin();
 
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);

--- a/samples/05-room-scale.html
+++ b/samples/05-room-scale.html
@@ -92,11 +92,28 @@ found in the LICENSE file.
       // ===================================================
 
       // WebGL setup.
-      var webglCanvas = document.getElementById("webgl-canvas");
       var gl = null;
       var cubeIsland = null;
       var stats = null;
       var debugGeom = null;
+
+      function onContextLost( event ) {
+        event.preventDefault();
+        console.log( 'WebGL Context Lost.' );
+        gl = null;
+        cubeIsland = null;
+        debugGeom = null;
+        stats = null;
+      }
+
+      function onContextRestored( event ) {
+        console.log( 'WebGL Context Restored.' );
+        initWebGL(vrDisplay ? vrDisplay.capabilities.hasExternalDisplay : false);
+      }
+
+      var webglCanvas = document.getElementById("webgl-canvas");
+      webglCanvas.addEventListener( 'webglcontextlost', onContextLost, false );
+      webglCanvas.addEventListener( 'webglcontextrestored', onContextRestored, false );
 
       function initWebGL (preserveDrawingBuffer) {
         var glAttribs = {
@@ -222,6 +239,8 @@ found in the LICENSE file.
             initWebGL(false);
             VRSamplesUtil.addInfo("WebVR supported, but no VRDisplays found.", 3000);
           }
+        }, function () {
+          VRSamplesUtil.addError("Your browser does not support WebVR. See <a href='http://webvr.info'>webvr.info</a> for assistance.");
         });
       } else if (navigator.getVRDevices) {
         initWebGL(false);
@@ -246,12 +265,34 @@ found in the LICENSE file.
 
       function onClick () {
         // Reset the background color to a random value
-        gl.clearColor(
+        if (gl) {
+          gl.clearColor(
             Math.random() * 0.5,
             Math.random() * 0.5,
             Math.random() * 0.5, 1.0);
+        }
       }
+
+      // Register for mouse restricted events while in VR
+      // (e.g. mouse no longer available on desktop 2D view)
+      function onDisplayPointerRestricted() {
+        if (webglCanvas && webglCanvas.requestPointerLock) {
+          webglCanvas.requestPointerLock();
+        }
+      }
+
+      // Register for mouse unrestricted events while in VR
+      // (e.g. mouse once again available on desktop 2D view)
+      function onDisplayPointerUnrestricted() {
+        var lock = document.pointerLockElement;
+        if (lock && lock === webglCanvas && document.exitPointerLock) {
+          document.exitPointerLock();
+        }
+      }
+
       webglCanvas.addEventListener("click", onClick, false);
+      window.addEventListener('vrdisplaypointerrestricted', onDisplayPointerRestricted);
+      window.addEventListener('vrdisplaypointerunrestricted', onDisplayPointerUnrestricted);
 
       // Get a matrix for the pose that takes into account the stageParameters
       // if we have them, and otherwise adjusts the position to ensure we're
@@ -291,6 +332,10 @@ found in the LICENSE file.
       }
 
       function onAnimationFrame (t) {
+        // do not attempt to render if there is no available WebGL context
+        if (!gl || !stats || !cubeIsland || !debugGeom) {
+          return;
+        }
         stats.begin();
 
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);

--- a/samples/06-vr-audio.html
+++ b/samples/06-vr-audio.html
@@ -95,11 +95,28 @@ found in the LICENSE file.
       // ================================================================
 
       // WebGL setup.
-      var webglCanvas = document.getElementById("webgl-canvas");
       var gl = null;
       var cubeIsland = null;
       var stats = null;
       var debugGeom = null;
+
+      function onContextLost( event ) {
+        event.preventDefault();
+        console.log( 'WebGL Context Lost.' );
+        gl = null;
+        cubeIsland = null;
+        debugGeom = null;
+        stats = null;
+      }
+
+      function onContextRestored( event ) {
+        console.log( 'WebGL Context Restored.' );
+        initWebGL(vrDisplay ? vrDisplay.capabilities.hasExternalDisplay : false);
+      }
+
+      var webglCanvas = document.getElementById("webgl-canvas");
+      webglCanvas.addEventListener( 'webglcontextlost', onContextLost, false );
+      webglCanvas.addEventListener( 'webglcontextrestored', onContextRestored, false );
 
       function initWebGL (preserveDrawingBuffer) {
         var glAttribs = {
@@ -144,24 +161,24 @@ found in the LICENSE file.
         window.requestAnimationFrame(onAnimationFrame);
       }
 
+      function getSoundFileData(audioFileFormat) {
+        return [
+          {
+            name: 'drums',
+            url: 'media/sound/drums.' + audioFileFormat
+          }, {
+            name: 'guitar',
+            url: 'media/sound/guitar.' + audioFileFormat
+          }, {
+            name: 'perc',
+            url: 'media/sound/perc.' + audioFileFormat
+          }
+        ];
+      }
+
       // WebAudio setup.
       var isAudioPannerReady = false;
       var drumSource, guitarSource, percSource;
-      var audioFileFormat = VRAudioPanner.isWebAudioOutdated() ? 'mp3' : 'ogg';
-
-      // For special Chromium build.
-      var soundFileData = [
-        {
-          name: 'drums',
-          url: 'media/sound/drums.' + audioFileFormat
-        }, {
-          name: 'guitar',
-          url: 'media/sound/guitar.' + audioFileFormat
-        }, {
-          name: 'perc',
-          url: 'media/sound/perc.' + audioFileFormat
-        }
-      ];
 
       function initAudio (buffers) {
         drumSource = VRAudioPanner.createTestSource({
@@ -201,12 +218,24 @@ found in the LICENSE file.
 
         // Load sound files and then initiate WebAudio.
         var infoElement = VRSamplesUtil.addInfo("Loading audio files...");
+        var audioFileFormat = VRAudioPanner.isWebAudioOutdated() ? 'mp3' : 'ogg';
 
-        VRAudioPanner
-          .loadAudioFiles(soundFileData, null)
+        VRAudioPanner.loadAudioFiles(getSoundFileData(audioFileFormat), null)
           .then(function (buffers) {
             VRSamplesUtil.makeToast(infoElement, 2000);
             initAudio(buffers);
+          }, function () {
+            if (audioFileFormat === "mp3") {
+              VRSamplesUtil.err("Can't load audio");
+              return;
+            }
+
+            // Fall back to mp3 file format
+            return VRAudioPanner.loadAudioFiles(getSoundFileData("mp3"))
+              .then(function(buffers) {
+                VRSamplesUtil.makeToast(infoElement, 2000);
+                initAudio(buffers);
+              });
           });
       }
 
@@ -277,6 +306,8 @@ found in the LICENSE file.
             init(false);
             VRSamplesUtil.addInfo("WebVR supported, but no VRDisplays found.", 3000);
           }
+        }, function () {
+          VRSamplesUtil.addError("Your browser does not support WebVR. See <a href='http://webvr.info'>webvr.info</a> for assistance.");
         });
       } else if (navigator.getVRDevices) {
         init(false);
@@ -301,12 +332,34 @@ found in the LICENSE file.
 
       function onClick () {
         // Reset the background color to a random value
-        gl.clearColor(
+        if (gl) {
+          gl.clearColor(
             Math.random() * 0.5,
             Math.random() * 0.5,
             Math.random() * 0.5, 1.0);
+        }
       }
+
+      // Register for mouse restricted events while in VR
+      // (e.g. mouse no longer available on desktop 2D view)
+      function onDisplayPointerRestricted() {
+        if (webglCanvas && webglCanvas.requestPointerLock) {
+          webglCanvas.requestPointerLock();
+        }
+      }
+
+      // Register for mouse unrestricted events while in VR
+      // (e.g. mouse once again available on desktop 2D view)
+      function onDisplayPointerUnrestricted() {
+        var lock = document.pointerLockElement;
+        if (lock && lock === webglCanvas && document.exitPointerLock) {
+          document.exitPointerLock();
+        }
+      }
+
       webglCanvas.addEventListener("click", onClick, false);
+      window.addEventListener('vrdisplaypointerrestricted', onDisplayPointerRestricted);
+      window.addEventListener('vrdisplaypointerunrestricted', onDisplayPointerUnrestricted);
 
       function getStandingViewMatrix (out, view) {
         if (vrDisplay.stageParameters) {
@@ -373,6 +426,10 @@ found in the LICENSE file.
       })();
 
       function onAnimationFrame (t) {
+        // do not attempt to render if there is no available WebGL context
+        if (!gl || !stats || !cubeIsland || !debugGeom) {
+          return;
+        }
         stats.begin();
 
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);

--- a/samples/07-advanced-mirroring.html
+++ b/samples/07-advanced-mirroring.html
@@ -95,16 +95,34 @@ found in the LICENSE file.
       // ===================================================
 
       // WebGL setup.
-      var webglCanvas = document.getElementById("webgl-canvas");
       var gl = null;
       var cubeIsland = null;
       var stats = null;
       var debugGeom = null;
 
-      function initWebGL () {
+      function onContextLost( event ) {
+        event.preventDefault();
+        console.log( 'WebGL Context Lost.' );
+        gl = null;
+        cubeIsland = null;
+        stats = null;
+        debugGeom = null;
+      }
+
+      function onContextRestored( event ) {
+        console.log( 'WebGL Context Restored.' );
+        initWebGL(vrDisplay ? vrDisplay.capabilities.hasExternalDisplay : false);
+      }
+
+      var webglCanvas = document.getElementById("webgl-canvas");
+      webglCanvas.addEventListener( 'webglcontextlost', onContextLost, false );
+      webglCanvas.addEventListener( 'webglcontextrestored', onContextRestored, false );
+
+      function initWebGL (preserveDrawingBuffer) {
         var glAttribs = {
           alpha: false,
-          // When doing mirroring like this, do NOT turn on PreserveDrawingBuffer!
+          // enable preserveDrawingBuffer to get updates on the external display too
+          preserveDrawingBuffer: preserveDrawingBuffer
         };
         var useWebgl2 = WGLUUrl.getBool('webgl2', false);
         var contextTypes = useWebgl2 ? ["webgl2"] : ["webgl", "experimental-webgl"];
@@ -192,7 +210,7 @@ found in the LICENSE file.
             vrDisplay.depthNear = 0.1;
             vrDisplay.depthFar = 1024.0;
 
-            initWebGL();
+            initWebGL(vrDisplay.capabilities.hasExternalDisplay);
 
             if (vrDisplay.stageParameters &&
                 vrDisplay.stageParameters.sizeX > 0 &&
@@ -211,15 +229,17 @@ found in the LICENSE file.
             window.addEventListener('vrdisplayactivate', onVRRequestPresent, false);
             window.addEventListener('vrdisplaydeactivate', onVRExitPresent, false);
           } else {
-            initWebGL();
+            initWebGL(false);
             VRSamplesUtil.addInfo("WebVR supported, but no VRDisplays found.", 3000);
           }
+        }, function () {
+          VRSamplesUtil.addError("Your browser does not support WebVR. See <a href='http://webvr.info'>webvr.info</a> for assistance.");
         });
       } else if (navigator.getVRDevices) {
-        initWebGL();
+        initWebGL(false);
         VRSamplesUtil.addError("Your browser supports WebVR but not the latest version. See <a href='http://webvr.info'>webvr.info</a> for more info.");
       } else {
-        initWebGL();
+        initWebGL(false);
         VRSamplesUtil.addError("Your browser does not support WebVR. See <a href='http://webvr.info'>webvr.info</a> for assistance.");
       }
 
@@ -238,12 +258,34 @@ found in the LICENSE file.
 
       function onClick () {
         // Reset the background color to a random value
-        gl.clearColor(
+        if (gl) {
+          gl.clearColor(
             Math.random() * 0.5,
             Math.random() * 0.5,
             Math.random() * 0.5, 1.0);
+        }
       }
+
+      // Register for mouse restricted events while in VR
+      // (e.g. mouse no longer available on desktop 2D view)
+      function onDisplayPointerRestricted() {
+        if (webglCanvas && webglCanvas.requestPointerLock) {
+          webglCanvas.requestPointerLock();
+        }
+      }
+
+      // Register for mouse unrestricted events while in VR
+      // (e.g. mouse once again available on desktop 2D view)
+      function onDisplayPointerUnrestricted() {
+        var lock = document.pointerLockElement;
+        if (lock && lock === webglCanvas && document.exitPointerLock) {
+          document.exitPointerLock();
+        }
+      }
+      
       webglCanvas.addEventListener("click", onClick, false);
+      window.addEventListener('vrdisplaypointerrestricted', onDisplayPointerRestricted);
+      window.addEventListener('vrdisplaypointerunrestricted', onDisplayPointerUnrestricted);
 
       function getStandingViewMatrix (out, view) {
         if (vrDisplay.stageParameters) {
@@ -296,6 +338,11 @@ found in the LICENSE file.
       }
 
       function onAnimationFrame (t) {
+        // do not attempt to render if there is no available WebGL context
+        if (!gl || !stats || !cubeIsland || !debugGeom) {
+          return;
+        }
+		
         stats.begin();
 
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
@@ -305,7 +352,7 @@ found in the LICENSE file.
 
           vrDisplay.getFrameData(frameData);
 
-          if(vrDisplay.isPresenting) {
+          if (vrDisplay.isPresenting) {
             gl.viewport(0, 0, webglCanvas.width * 0.5, webglCanvas.height);
             getStandingViewMatrix(viewMat, frameData.leftViewMatrix);
             cubeIsland.render(frameData.leftProjectionMatrix, viewMat, stats);

--- a/samples/08-dynamic-resolution.html
+++ b/samples/08-dynamic-resolution.html
@@ -102,11 +102,28 @@ found in the LICENSE file.
       // ================================
 
       // WebGL setup.
-      var webglCanvas = document.getElementById("webgl-canvas");
-      var canvasClip = document.getElementById("canvas-clip");
       var gl = null;
       var cubeSea = null;
       var stats = null;
+
+      function onContextLost( event ) {
+        event.preventDefault();
+        console.log( 'WebGL Context Lost.' );
+        gl = null;
+        cubeSea = null;
+        stats = null;
+      }
+
+      function onContextRestored( event ) {
+        console.log( 'WebGL Context Restored.' );
+        initWebGL(vrDisplay ? vrDisplay.capabilities.hasExternalDisplay : false);
+      }
+
+      var webglCanvas = document.getElementById("webgl-canvas");
+      webglCanvas.addEventListener( 'webglcontextlost', onContextLost, false );
+      webglCanvas.addEventListener( 'webglcontextrestored', onContextRestored, false );
+
+      var canvasClip = document.getElementById("canvas-clip");
 
       function initWebGL (preserveDrawingBuffer) {
         var glAttribs = {
@@ -213,6 +230,8 @@ found in the LICENSE file.
             initWebGL(false);
             VRSamplesUtil.addInfo("WebVR supported, but no VRDisplays found.", 3000);
           }
+        }, function () {
+          VRSamplesUtil.addError("Your browser does not support WebVR. See <a href='http://webvr.info'>webvr.info</a> for assistance.");
         });
       } else if (navigator.getVRDevices) {
         initWebGL(false);
@@ -237,12 +256,34 @@ found in the LICENSE file.
 
       function onClick () {
         // Reset the background color to a random value
-        gl.clearColor(
+        if (gl) {
+          gl.clearColor(
             Math.random() * 0.5,
             Math.random() * 0.5,
             Math.random() * 0.5, 1.0);
+        }
       }
+      
+      // Register for mouse restricted events while in VR
+      // (e.g. mouse no longer available on desktop 2D view)
+      function onDisplayPointerRestricted() {
+        if (webglCanvas && webglCanvas.requestPointerLock) {
+          webglCanvas.requestPointerLock();
+        }
+      }
+
+      // Register for mouse unrestricted events while in VR
+      // (e.g. mouse once again available on desktop 2D view)
+      function onDisplayPointerUnrestricted() {
+        var lock = document.pointerLockElement;
+        if (lock && lock === webglCanvas && document.exitPointerLock) {
+          document.exitPointerLock();
+        }
+      }
+      
       webglCanvas.addEventListener("click", onClick, false);
+      window.addEventListener('vrdisplaypointerrestricted', onDisplayPointerRestricted);
+      window.addEventListener('vrdisplaypointerunrestricted', onDisplayPointerUnrestricted);
 
       // How large our frame should be in relation to the recommended render
       // target size.
@@ -291,6 +332,10 @@ found in the LICENSE file.
       }
 
       function onAnimationFrame (t) {
+        // do not attempt to render if there is no available WebGL context
+        if (!gl || !stats || !cubeSea) {
+          return;
+        }
         stats.begin();
 
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);

--- a/samples/09-splash-screen.html
+++ b/samples/09-splash-screen.html
@@ -124,6 +124,25 @@ found in the LICENSE file.
       var textureLoader = null;
       var splashScreen = null;
 
+      function onContextLost( event ) {
+        event.preventDefault();
+        console.log( 'WebGL Context Lost.' );
+        gl = null;
+        cubeSea = null;
+        stats = null;
+        textureLoader = null;
+        splashScreen = null;
+      }
+
+      function onContextRestored( event ) {
+        console.log( 'WebGL Context Restored.' );
+        initWebGL(vrDisplay ? vrDisplay.capabilities.hasExternalDisplay : false);
+      }
+
+      webglCanvas = document.createElement('canvas');
+      webglCanvas.addEventListener( 'webglcontextlost', onContextLost, false );
+      webglCanvas.addEventListener( 'webglcontextrestored', onContextRestored, false );
+
       // This sample is going to use a slightly different start up sequence.
       // In order to show the splash screen effect we won't have any magic
       // window content and only begin loading the scene once the "Enter VR"
@@ -131,7 +150,6 @@ found in the LICENSE file.
       // splash screen and let it reproject while the real scene loads. Once
       // that scene is ready we'll begin rendering it.
       function initWebGL (preserveDrawingBuffer) {
-        webglCanvas = document.createElement('canvas');
         var glAttribs = {
           alpha: false,
           preserveDrawingBuffer: preserveDrawingBuffer
@@ -278,6 +296,11 @@ found in the LICENSE file.
       }
 
       function onSplashFrame (t) {
+        // do not attempt to render if there is no available WebGL context
+        if (!gl) {
+          return;
+        }
+
         // Splash screens should always be cleared to black to avoid showing the
         // edges of the reprojected frame
         gl.clearColor(0.0, 0.0, 0.0, 1.0);
@@ -311,8 +334,11 @@ found in the LICENSE file.
       }
 
       function onAnimationFrame (t) {
-        if (!vrDisplay.isPresenting)
+        // do not attempt to render if there is no available WebGL context
+        if (!gl || !stats || !cubeSea) {
+          window.requestAnimationFrame(onAnimationFrame);
           return;
+        }
 
         stats.begin();
 

--- a/samples/XX-360-panorama.html
+++ b/samples/XX-360-panorama.html
@@ -88,10 +88,26 @@ found in the LICENSE file.
       // ================================================================
 
       // WebGL setup.
-      var webglCanvas = document.getElementById("webgl-canvas");
       var gl = null;
       var panorama = null;
       var stats = null;
+
+      function onContextLost( event ) {
+        event.preventDefault();
+        console.log( 'WebGL Context Lost.' );
+        gl = null;
+        panorama = null;
+        stats = null;
+      }
+
+      function onContextRestored( event ) {
+        console.log( 'WebGL Context Restored.' );
+        init(vrDisplay ? vrDisplay.capabilities.hasExternalDisplay : false);
+      }
+
+      var webglCanvas = document.getElementById("webgl-canvas");
+      webglCanvas.addEventListener( 'webglcontextlost', onContextLost, false );
+      webglCanvas.addEventListener( 'webglcontextrestored', onContextRestored, false );
 
       function init (preserveDrawingBuffer) {
         var glAttribs = {
@@ -189,6 +205,8 @@ found in the LICENSE file.
             init(false);
             VRSamplesUtil.addInfo("WebVR supported, but no VRDisplays found.", 3000);
           }
+        }, function () {
+          VRSamplesUtil.addError("Your browser does not support WebVR. See <a href='http://webvr.info'>webvr.info</a> for assistance.");
         });
       } else if (navigator.getVRDevices) {
         init(false);
@@ -222,6 +240,10 @@ found in the LICENSE file.
       }
 
       function onAnimationFrame (t) {
+        // do not attempt to render if there is no available WebGL context
+        if (!gl || !stats || !panorama) {
+          return;
+        }
         stats.begin();
 
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);

--- a/samples/XX-360-video.html
+++ b/samples/XX-360-video.html
@@ -88,10 +88,26 @@ found in the LICENSE file.
       // ================================================================
 
       // WebGL setup.
-      var webglCanvas = document.getElementById("webgl-canvas");
       var gl = null;
       var panorama = null;
       var stats = null;
+
+      function onContextLost( event ) {
+        event.preventDefault();
+        console.log( 'WebGL Context Lost.' );
+        gl = null;
+        panorama = null;
+        stats = null;
+      }
+
+      function onContextRestored( event ) {
+        console.log( 'WebGL Context Restored.' );
+        init(vrDisplay ? vrDisplay.capabilities.hasExternalDisplay : false);
+      }
+
+      var webglCanvas = document.getElementById("webgl-canvas");
+      webglCanvas.addEventListener( 'webglcontextlost', onContextLost, false );
+      webglCanvas.addEventListener( 'webglcontextrestored', onContextRestored, false );
 
       function init (preserveDrawingBuffer) {
         var glAttribs = {
@@ -198,6 +214,8 @@ found in the LICENSE file.
             init(false);
             VRSamplesUtil.addInfo("WebVR supported, but no VRDisplays found.", 3000);
           }
+        }, function () {
+          VRSamplesUtil.addError("Your browser does not support WebVR. See <a href='http://webvr.info'>webvr.info</a> for assistance.");
         });
       } else if (navigator.getVRDevices) {
         init(false);
@@ -231,6 +249,10 @@ found in the LICENSE file.
       }
 
       function onAnimationFrame (t) {
+        // do not attempt to render if there is no available WebGL context
+        if (!gl || !stats || !panorama) {
+          return;
+        }
         stats.begin();
 
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);

--- a/samples/XX-vr-controllers.html
+++ b/samples/XX-vr-controllers.html
@@ -18,9 +18,9 @@ found in the LICENSE file.
 
     <!--
       This sample demonstrates how to handle gamepads with 6DoF support, such as
-      the Vive controllers or Oculus touch. PLEASE NOTE: The additions to the
-      gamepad API used here are not yet part of the standard, and subject to
-      change at any time!
+      the Vive controllers, Oculus touch or Windows Motion controllers.
+      PLEASE NOTE: The additions to the gamepad API used here are not yet
+      part of the standard, and subject to change at any time!
     -->
 
     <style>
@@ -102,11 +102,28 @@ found in the LICENSE file.
       // ===================================================
 
       // WebGL setup.
-      var webglCanvas = document.getElementById("webgl-canvas");
       var gl = null;
       var cubeIsland = null;
       var stats = null;
       var debugGeom = null;
+
+      function onContextLost( event ) {
+        event.preventDefault();
+        console.log( 'WebGL Context Lost.' );
+        gl = null;
+        cubeIsland = null;
+        stats = null;
+        debugGeom = null;
+      }
+
+      function onContextRestored( event ) {
+        console.log( 'WebGL Context Restored.' );
+        initWebGL(vrDisplay ? vrDisplay.capabilities.hasExternalDisplay : false);
+      }
+
+      var webglCanvas = document.getElementById("webgl-canvas");
+      webglCanvas.addEventListener( 'webglcontextlost', onContextLost, false );
+      webglCanvas.addEventListener( 'webglcontextrestored', onContextRestored, false );
 
       function initWebGL (preserveDrawingBuffer) {
         var glAttribs = {
@@ -213,6 +230,8 @@ found in the LICENSE file.
             initWebGL(false);
             VRSamplesUtil.addInfo("WebVR supported, but no VRDisplays found.", 3000);
           }
+        }, function () {
+          VRSamplesUtil.addError("Your browser does not support WebVR. See <a href='http://webvr.info'>webvr.info</a> for assistance.");
         });
       } else if (navigator.getVRDevices) {
         initWebGL(false);
@@ -392,6 +411,10 @@ found in the LICENSE file.
       }
 
       function onAnimationFrame (t) {
+        // do not attempt to render if there is no available WebGL context
+        if (!gl || !stats || !cubeIsland || !debugGeom) {
+          return;
+        }
         stats.begin();
 
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);

--- a/samples/insecure/test-insecure.html
+++ b/samples/insecure/test-insecure.html
@@ -94,42 +94,64 @@ found in the LICENSE file.
       var viewMat = mat4.create();
 
       var vrPresentButton = null;
+      var presentingMessage = document.getElementById("presenting-message");
 
       // ===================================================
       // WebGL scene setup. This code is not WebVR specific.
       // ===================================================
 
       // WebGL setup.
-      var webglCanvas = document.getElementById("webgl-canvas");
-      var glAttribs = {
-        alpha: false,
-      };
-      var useWebgl2 = WGLUUrl.getBool('webgl2', false);
-      var contextTypes = useWebgl2 ? ["webgl2"] : ["webgl", "experimental-webgl"];
       var gl = null;
-      for (var i in contextTypes) {
-        gl = webglCanvas.getContext(contextTypes[i], glAttribs);
-        if (gl)
-          break;
+      var cubeSea = null;
+      var stats = null;
+
+      function onContextLost( event ) {
+        event.preventDefault();
+        console.log( 'WebGL Context Lost.' );
+        gl = null;
+        cubeSea = null;
+        stats = null;
       }
-      if (!gl) {
-        var webglType = (useWebgl2 ? "WebGL 2" : "WebGL")
-        VRSamplesUtil.addError("Your browser does not support " + webglType + ".");
-        return;
+
+      function onContextRestored( event ) {
+        console.log( 'WebGL Context Restored.' );
+        initWebGL();
       }
-      gl.clearColor(0.1, 0.2, 0.3, 1.0);
-      gl.enable(gl.DEPTH_TEST);
-      gl.enable(gl.CULL_FACE);
 
-      var textureLoader = new WGLUTextureLoader(gl);
-      var texture = textureLoader.loadTexture("../media/textures/cube-sea.png");
-      var cubeSea = new VRCubeSea(gl, texture);
+      var webglCanvas = document.getElementById("webgl-canvas");
+      webglCanvas.addEventListener( 'webglcontextlost', onContextLost, false );
+      webglCanvas.addEventListener( 'webglcontextrestored', onContextRestored, false );
 
-      var enablePerformanceMonitoring = WGLUUrl.getBool(
-          'enablePerformanceMonitoring', false);
-      var stats = new WGLUStats(gl, enablePerformanceMonitoring);
+      function initWebGL() {
+        var glAttribs = {
+          alpha: false,
+        };
+        var useWebgl2 = WGLUUrl.getBool('webgl2', false);
+        var contextTypes = useWebgl2 ? ["webgl2"] : ["webgl", "experimental-webgl"];
 
-      var presentingMessage = document.getElementById("presenting-message");
+        for (var i in contextTypes) {
+          gl = webglCanvas.getContext(contextTypes[i], glAttribs);
+          if (gl)
+            break;
+        }
+        if (!gl) {
+          var webglType = (useWebgl2 ? "WebGL 2" : "WebGL")
+          VRSamplesUtil.addError("Your browser does not support " + webglType + ".");
+          return;
+        }
+        gl.clearColor(0.1, 0.2, 0.3, 1.0);
+        gl.enable(gl.DEPTH_TEST);
+        gl.enable(gl.CULL_FACE);
+
+        var textureLoader = new WGLUTextureLoader(gl);
+        var texture = textureLoader.loadTexture("../media/textures/cube-sea.png");
+        cubeSea = new VRCubeSea(gl, texture);
+
+        var enablePerformanceMonitoring = WGLUUrl.getBool(
+            'enablePerformanceMonitoring', false);
+        stats = new WGLUStats(gl, enablePerformanceMonitoring);
+      }
+      initWebGL();
 
       // ================================
       // WebVR-specific code begins here.
@@ -181,7 +203,7 @@ found in the LICENSE file.
             // On devices with an external display the UA may not provide a way
             // to exit VR presentation mode, so we should provide one ourselves.
             VRSamplesUtil.removeButton(vrPresentButton);
-            vrPresentButton = VRSamplesUtil.addButton("Exit VR", "E", "media/icons/cardboard64.png", onVRExitPresent);
+            vrPresentButton = VRSamplesUtil.addButton("Exit VR", "E", "../media/icons/cardboard64.png", onVRExitPresent);
           }
         } else {
           // If we have an external display take down the presenting message and
@@ -190,7 +212,7 @@ found in the LICENSE file.
             presentingMessage.style.display = "";
 
             VRSamplesUtil.removeButton(vrPresentButton);
-            vrPresentButton = VRSamplesUtil.addButton("Enter VR", "E", "media/icons/cardboard64.png", onVRRequestPresent);
+            vrPresentButton = VRSamplesUtil.addButton("Enter VR", "E", "../media/icons/cardboard64.png", onVRRequestPresent);
           }
         }
       }
@@ -212,7 +234,7 @@ found in the LICENSE file.
             // you know the user has a VRDisplay capable of presenting connected
             // before adding UI that advertises VR features.
             if (vrDisplay.capabilities.canPresent)
-              vrPresentButton = VRSamplesUtil.addButton("Enter VR", "E", "media/icons/cardboard64.png", onVRRequestPresent);
+              vrPresentButton = VRSamplesUtil.addButton("Enter VR", "E", "../media/icons/cardboard64.png", onVRRequestPresent);
 
             // For the benefit of automated testing. Safe to ignore.
             if (vrDisplay.capabilities.canPresent && WGLUUrl.getBool('canvasClickPresents', false))
@@ -234,6 +256,8 @@ found in the LICENSE file.
           } else {
             VRSamplesUtil.addInfo("WebVR supported, but no VRDisplays found.", 3000);
           }
+        }, function () {
+          VRSamplesUtil.addError("Your browser does not support WebVR. See <a href='http://webvr.info'>webvr.info</a> for assistance.");
         });
       } else if (navigator.getVRDevices) {
         VRSamplesUtil.addError("Your browser supports WebVR but not the latest version. See <a href='http://webvr.info'>webvr.info</a> for more info.");
@@ -272,14 +296,40 @@ found in the LICENSE file.
       // should ideally always be minimally supported.
       function onClick () {
         // Reset the background color to a random value
-        gl.clearColor(
+        if (gl) {
+          gl.clearColor(
             Math.random() * 0.5,
             Math.random() * 0.5,
             Math.random() * 0.5, 1.0);
+        }
       }
+
+      // Register for mouse restricted events while in VR
+      // (e.g. mouse no longer available on desktop 2D view)
+      function onDisplayPointerRestricted() {
+        if (webglCanvas && webglCanvas.requestPointerLock) {
+          webglCanvas.requestPointerLock();
+        }
+      }
+
+      // Register for mouse unrestricted events while in VR
+      // (e.g. mouse once again available on desktop 2D view)
+      function onDisplayPointerUnrestricted() {
+        var lock = document.pointerLockElement;
+        if (lock && lock === webglCanvas && document.exitPointerLock) {
+          document.exitPointerLock();
+        }
+      }
+
       webglCanvas.addEventListener("click", onClick, false);
+      window.addEventListener('vrdisplaypointerrestricted', onDisplayPointerRestricted);
+      window.addEventListener('vrdisplaypointerunrestricted', onDisplayPointerUnrestricted);
 
       function onAnimationFrame (t) {
+        // do not attempt to render if there is no available WebGL context
+        if (!gl || !stats || !cubeSea) {
+          return;
+        }
         stats.begin();
 
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);

--- a/samples/test-canvas-attributes.html
+++ b/samples/test-canvas-attributes.html
@@ -43,9 +43,27 @@ found in the LICENSE file.
       var viewMat = mat4.create();
       var presentingCanvas = null;
 
+      // Register for mouse restricted events while in VR
+      // (e.g. mouse no longer available on desktop 2D view)
+      function onDisplayPointerRestricted() {
+        if (presentingCanvas && presentingCanvas.requestPointerLock) {
+          presentingCanvas.requestPointerLock();
+        }
+      }
+
+      // Register for mouse unrestricted events while in VR
+      // (e.g. mouse once again available on desktop 2D view)
+      function onDisplayPointerUnrestricted() {
+        var lock = document.pointerLockElement;
+        if (lock && lock === presentingCanvas && document.exitPointerLock) {
+          document.exitPointerLock();
+        }
+      }
+
       function onVRRequestPresent (canvas) {
         // This can only be called in response to a user gesture.
         vrDisplay.requestPresent([{ source: canvas }]).then(function () {
+          onDisplayPointerUnrestricted();
           presentingCanvas = canvas;
         }, function (err) {
           var errMsg = "requestPresent failed.";
@@ -56,6 +74,9 @@ found in the LICENSE file.
         });
       }
 
+      window.addEventListener('vrdisplaypointerrestricted', onDisplayPointerRestricted);
+      window.addEventListener('vrdisplaypointerunrestricted', onDisplayPointerUnrestricted);
+
       window.addEventListener('vrdisplaypresentchange', function() {
         if (!vrDisplay.isPresenting) {
           presentingCanvas = null;
@@ -64,7 +85,52 @@ found in the LICENSE file.
 
       function appendCanvas(name, glAttribs) {
         // WebGL setup.
+        var gl = null;
+        var cubeSea = null;
+        var stats = null;
+
+        function initWebGL() {
+          gl = webglCanvas.getContext("webgl", glAttribs);
+          if (!gl) {
+            gl = webglCanvas.getContext("experimental-webgl", glAttribs);
+            if (!gl) {
+              VRSamplesUtil.addError("Your browser does not support WebGL.");
+              return;
+            }
+          }
+
+          gl.clearColor(0.1, 0.2, 0.3, 1.0);
+          gl.enable(gl.DEPTH_TEST);
+          gl.enable(gl.CULL_FACE);
+
+          var textureLoader = new WGLUTextureLoader(gl);
+          var texture = textureLoader.loadTexture("media/textures/cube-sea.png");
+          cubeSea = new VRCubeSea(gl, texture);
+
+          var enablePerformanceMonitoring = WGLUUrl.getBool(
+              'enablePerformanceMonitoring', false);
+          stats = new WGLUStats(gl, enablePerformanceMonitoring);
+        }
+
+        function onContextLost( event ) {
+          event.preventDefault();
+          console.log( 'WebGL Context Lost.' );
+          gl = null;
+          cubeSea = null;
+          stats = null;
+        }
+
+        function onContextRestored( event ) {
+          console.log( 'WebGL Context Restored.' );
+          initWebGL();
+        }
+
         var webglCanvas = document.createElement("canvas");
+        webglCanvas.addEventListener( 'webglcontextlost', onContextLost, false );
+        webglCanvas.addEventListener( 'webglcontextrestored', onContextRestored, false );
+
+
+        initWebGL();
 
         var container = document.createElement("div");
         container.appendChild(webglCanvas);
@@ -89,34 +155,22 @@ found in the LICENSE file.
 
         function onClick () {
           // Reset the background color to a random value
-          gl.clearColor(
+          if (gl) {
+            gl.clearColor(
               Math.random() * 0.5,
               Math.random() * 0.5,
               Math.random() * 0.5, 1.0);
+          }
         }
         webglCanvas.addEventListener("click", onClick, false);
 
-        var gl = webglCanvas.getContext("webgl", glAttribs);
-        if (!gl) {
-          gl = webglCanvas.getContext("experimental-webgl", glAttribs);
-          if (!gl) {
-            VRSamplesUtil.addError("Your browser does not support WebGL.");
-            return;
-          }
-        }
-        gl.clearColor(0.1, 0.2, 0.3, 1.0);
-        gl.enable(gl.DEPTH_TEST);
-        gl.enable(gl.CULL_FACE);
-
-        var textureLoader = new WGLUTextureLoader(gl);
-        var texture = textureLoader.loadTexture("media/textures/cube-sea.png");
-        var cubeSea = new VRCubeSea(gl, texture);
-
-        var enablePerformanceMonitoring = WGLUUrl.getBool(
-            'enablePerformanceMonitoring', false);
-        var stats = new WGLUStats(gl, enablePerformanceMonitoring);
 
         function onAnimationFrame (t) {
+          // do not attempt to render if there is no available WebGL context
+          if (!gl || !stats || !cubeSea) {
+            return;
+          }
+
           stats.begin();
 
           gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
@@ -177,6 +231,8 @@ found in the LICENSE file.
           } else {
             VRSamplesUtil.addInfo("WebVR supported, but no VRDisplays found.", 3000);
           }
+        }, function () {
+          VRSamplesUtil.addError("Your browser does not support WebVR. See <a href='http://webvr.info'>webvr.info</a> for assistance.");
         });
       } else if (navigator.getVRDevices) {
         VRSamplesUtil.addError("Your browser supports WebVR but not the latest version. See <a href='http://webvr.info'>webvr.info</a> for more info.");

--- a/samples/test-slow-render.html
+++ b/samples/test-slow-render.html
@@ -97,10 +97,26 @@ found in the LICENSE file.
       // ================================
 
       // WebGL setup.
-      var webglCanvas = document.getElementById("webgl-canvas");
       var gl = null;
       var cubeSea = null;
       var stats = null;
+
+      function onContextLost( event ) {
+        event.preventDefault();
+        console.log( 'WebGL Context Lost.' );
+        gl = null;
+        cubeSea = null;
+        stats = null;
+      }
+
+      function onContextRestored( event ) {
+        console.log( 'WebGL Context Restored.' );
+        initWebGL(vrDisplay ? vrDisplay.capabilities.hasExternalDisplay : false);
+      }
+
+      var webglCanvas = document.getElementById("webgl-canvas");
+      webglCanvas.addEventListener( 'webglcontextlost', onContextLost, false );
+      webglCanvas.addEventListener( 'webglcontextrestored', onContextRestored, false );
 
       function initWebGL (preserveDrawingBuffer) {
         var glAttribs = {
@@ -194,6 +210,8 @@ found in the LICENSE file.
             initWebGL(false);
             VRSamplesUtil.addInfo("WebVR supported, but no VRDisplays found.", 3000);
           }
+        }, function () {
+          VRSamplesUtil.addError("Your browser does not support WebVR. See <a href='http://webvr.info'>webvr.info</a> for assistance.");
         });
       } else if (navigator.getVRDevices) {
         initWebGL(false);
@@ -225,6 +243,10 @@ found in the LICENSE file.
       var now = (window.performance && performance.now) ? performance.now.bind(performance) : Date.now;
 
       function onAnimationFrame (t) {
+        // do not attempt to render if there is no available WebGL context
+        if (!gl || !stats || !cubeSea) {
+          return;
+        }
         stats.begin();
 
         if (simulatedWorkTimeMs > 0) {

--- a/samples/test-vr-links.html
+++ b/samples/test-vr-links.html
@@ -100,45 +100,74 @@ found in the LICENSE file.
       var viewMat = mat4.create();
 
       var vrPresentButton = null;
+      var presentingMessage = document.getElementById("presenting-message");
 
+      var nextPageId;
+      
       // ===================================================
       // WebGL scene setup. This code is not WebVR specific.
       // ===================================================
 
       // WebGL setup.
-      var webglCanvas = document.getElementById("webgl-canvas");
-      var glAttribs = {
-        alpha: false,
-      };
-      var pageId = WGLUUrl.getInt('id', 0);
-      var nextPageId = pageId + 1;
-      var useWebgl2 = WGLUUrl.getBool('webgl2', false);
-      var contextTypes = useWebgl2 ? ["webgl2"] : ["webgl", "experimental-webgl"];
       var gl = null;
-      for (var i in contextTypes) {
-        gl = webglCanvas.getContext(contextTypes[i], glAttribs);
-        if (gl)
-          break;
+      var cubeIsland = null;
+      var debugGeom = null;
+      var stats = null;
+      
+      function onContextLost( event ) {
+        event.preventDefault();
+        console.log( 'WebGL Context Lost.' );
+        gl = null;
+        cubeIsland = null;
+        debugGeom = null;
+        stats = null;
       }
-      if (!gl) {
-        var webglType = (useWebgl2 ? "WebGL 2" : "WebGL")
-        VRSamplesUtil.addError("Your browser does not support " + webglType + ".");
-        return;
+
+      function onContextRestored( event ) {
+        console.log( 'WebGL Context Restored.' );
+        initWebGL();
       }
-      gl.clearColor(0.1, 0.2, 0.3, 1.0);
-      gl.enable(gl.DEPTH_TEST);
-      gl.enable(gl.CULL_FACE);
+      
+      var webglCanvas = document.getElementById("webgl-canvas");
+      webglCanvas.addEventListener( 'webglcontextlost', onContextLost, false );
+      webglCanvas.addEventListener( 'webglcontextrestored', onContextRestored, false );
 
-      var textureLoader = new WGLUTextureLoader(gl);
-      var texture = textureLoader.loadTexture("media/textures/cube-sea.png");
-      var cubeIsland = new VRCubeIsland(gl, texture, 2, 2);
-      var debugGeom = new WGLUDebugGeometry(gl);
+      function initWebGL() {
+        var glAttribs = {
+          alpha: false,
+        };
+        var pageId = WGLUUrl.getInt('id', 0);
+        nextPageId = pageId + 1;
+        var useWebgl2 = WGLUUrl.getBool('webgl2', false);
+        var contextTypes = useWebgl2 ? ["webgl2"] : ["webgl", "experimental-webgl"];
+        for (var i in contextTypes) {
+          gl = webglCanvas.getContext(contextTypes[i], glAttribs);
+          if (gl)
+            break;
+        }
+        if (!gl) {
+          var webglType = (useWebgl2 ? "WebGL 2" : "WebGL")
+          VRSamplesUtil.addError("Your browser does not support " + webglType + ".");
+          return;
+        }
+        gl.clearColor(0.1, 0.2, 0.3, 1.0);
+        gl.enable(gl.DEPTH_TEST);
+        gl.enable(gl.CULL_FACE);
+        
+        var textureLoader = new WGLUTextureLoader(gl);
+        var texture = textureLoader.loadTexture("media/textures/cube-sea.png");
+        cubeIsland = new VRCubeIsland(gl, texture, 2, 2);
+        debugGeom = new WGLUDebugGeometry(gl);
+        
+        var enablePerformanceMonitoring = WGLUUrl.getBool(
+            'enablePerformanceMonitoring', false);
+        stats = new WGLUStats(gl, enablePerformanceMonitoring);
 
-      var enablePerformanceMonitoring = WGLUUrl.getBool(
-          'enablePerformanceMonitoring', false);
-      var stats = new WGLUStats(gl, enablePerformanceMonitoring);
-
-      var presentingMessage = document.getElementById("presenting-message");
+        window.addEventListener("resize", onResize, false);
+        onResize();
+        window.requestAnimationFrame(onAnimationFrame);
+      }
+      initWebGL();
 
       // ================================
       // WebVR-specific code begins here.
@@ -221,6 +250,8 @@ found in the LICENSE file.
           } else {
             VRSamplesUtil.addInfo("WebVR supported, but no VRDisplays found.", 3000);
           }
+        }, function () {
+          VRSamplesUtil.addError("Your browser does not support WebVR. See <a href='http://webvr.info'>webvr.info</a> for assistance.");
         });
       } else if (navigator.getVRDevices) {
         VRSamplesUtil.addError("Your browser supports WebVR but not the latest version. See <a href='http://webvr.info'>webvr.info</a> for more info.");
@@ -240,8 +271,6 @@ found in the LICENSE file.
           webglCanvas.height = webglCanvas.offsetHeight * window.devicePixelRatio;
         }
       }
-      window.addEventListener("resize", onResize, false);
-      onResize();
 
       var leftIntersect = false;
       var rightIntersect = false;
@@ -259,14 +288,36 @@ found in the LICENSE file.
           // Navigate to a 2D site
           window.location = "index.html"
         } else {
-          // Reset the background color to a random value
-          gl.clearColor(
-              Math.random() * 0.5,
-              Math.random() * 0.5,
-              Math.random() * 0.5, 1.0);
+          if (gl) {
+            // Reset the background color to a random value
+            gl.clearColor(
+                Math.random() * 0.5,
+                Math.random() * 0.5,
+                Math.random() * 0.5, 1.0);
+          }
         }
       }
+      
+      // Register for mouse restricted events while in VR
+      // (e.g. mouse no longer available on desktop 2D view)
+      function onDisplayPointerRestricted() {
+        if (webglCanvas && webglCanvas.requestPointerLock) {
+          webglCanvas.requestPointerLock();
+        }
+      }
+
+      // Register for mouse unrestricted events while in VR
+      // (e.g. mouse once again available on desktop 2D view)
+      function onDisplayPointerUnrestricted() {
+        var lock = document.pointerLockElement;
+        if (lock && lock === webglCanvas && document.exitPointerLock) {
+          document.exitPointerLock();
+        }
+      }
+      
       webglCanvas.addEventListener("click", onClick, false);
+      window.addEventListener('vrdisplaypointerrestricted', onDisplayPointerRestricted);
+      window.addEventListener('vrdisplaypointerunrestricted', onDisplayPointerUnrestricted);
 
       function getStandingViewMatrix (out, view) {
         if (vrDisplay.stageParameters) {
@@ -325,6 +376,11 @@ found in the LICENSE file.
       }
 
       function onAnimationFrame (t) {
+        // do not attempt to render if there is no available WebGL context
+        if (!gl || !stats || !cubeIsland || !debugGeom) {
+          window.requestAnimationFrame(onAnimationFrame);
+          return;
+        }
         stats.begin();
 
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
@@ -369,7 +425,6 @@ found in the LICENSE file.
 
         stats.end();
       }
-      window.requestAnimationFrame(onAnimationFrame);
       })();
     </script>
   </body>


### PR DESCRIPTION
… (for support on hybrid machines)


This pull request addresses the following problems:
 - handle WebGL context lost and restored events for support on machines with multiple GPUs;
 - handle vrdisplaypointerrestricted events to get mouse focus on the presenting canvas (to allow for mouse click handling);
 - show error message if getVRDisplays rejects;
 - fall back to mp3 audio file format if ogg loading rejects;
 - advanced mirroring example should use preserveDrawingBuffer=true to render updates on the external display