### PR TITLE
Remove duplicate requestAnimationFrame

### DIFF
--- a/samples/03-vr-presentation.html
+++ b/samples/03-vr-presentation.html
@@ -157,7 +157,6 @@ found in the LICENSE file.
         // Wait until we have a WebGL context to resize and start rendering.
         window.addEventListener("resize", onResize, false);
         onResize();
-        window.requestAnimationFrame(onAnimationFrame);
       }
       initWebGL();
 


### PR DESCRIPTION
This was leading to confused 120fps readings from the built-in stats counter.