### PR TITLE
Fixing panorama

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-slate

--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-slate

--- a/samples/js/vr-panorama.js
+++ b/samples/js/vr-panorama.js
@@ -160,10 +160,15 @@ window.VRPanorama = (function () {
       }, false);
 
       video.loop = true;
-      video.autoplay = true;
+      // Videos must be muted to play without a user gesture.
+      video.muted = true;
       video.crossOrigin = 'anonymous';
       video.setAttribute('webkit-playsinline', '');
       video.src = url;
+      // As the video is never visible on the page, we must explicitly
+      // call play to start the video instead of being able to use
+      // autoplay attributes.
+      video.play();
     });
   };
 


### PR DESCRIPTION
autoplay does not work on mobile for video which is not visible on the page. Videos must also be muted, else they will not play without a user gesture. 