### PR TITLE
Fix Firefox references

### DIFF
--- a/developers/index.html
+++ b/developers/index.html
@@ -40,14 +40,15 @@
           <a id="how-can-i-try-it" class="anchor" href="#how-can-i-try-it" aria-hidden="true"><span class="octicon octicon-link"></span></a>How can I try it?
         </h3>
 
-        <p>The WebVR API is currently available in <a href="https://nightly.mozilla.org/">Firefox Nightly builds</a>, in <a href="https://www.google.com/chrome/browser/mobile/index.html">Chrome 56+ for Android</a> and <a href="get-chrome/">experimental builds of Chromium for Windows</a>, <a href="https://blogs.windows.com/msedgedev/2017/04/11/introducing-edgehtml-15/#8e8xdJQ1oybkrxB8.97">Microsoft Edge for Windows</a> and the <a href="http://developer.samsung.com/technical-doc/view.do?v=T000000202">Samsung Internet Browser for Gear VR</a>, <a href="https://www.supermedium.com">Supermedium</a>. You can get the latest WebVR-enabled builds here:</p>
+        <p>The WebVR API is currently available in <a href="https://webvr.rocks/firefox">Firefox</a>, <a href="get-chrome/">experimental builds of Chromium</a>, <a href="https://blogs.windows.com/msedgedev/2017/04/11/introducing-edgehtml-15/#8e8xdJQ1oybkrxB8.97">Microsoft Edge</a> and <a href="https://www.supermedium.com">Supermedium</a> on Windows;
+          <a href="https://nightly.mozilla.org/">Firefox Nightly builds</a> on macOS; <a href="https://www.google.com/chrome/browser/mobile/index.html">Chrome 56+ for Android</a> and <a href="http://developer.samsung.com/technical-doc/view.do?v=T000000202">Samsung Internet Browser for Gear VR</a>. You can get the latest WebVR-enabled builds here:</p>
 
         <ul class="browsers">
           <li>
             <a href="https://www.google.com/chrome/browser/mobile/index.html" class="link-important">Download Chrome for Android</a> (<a href="https://webvr.rocks/chrome_for_android#setup">read instructions</a>)
           </li>
           <li>
-            <a href="https://webvr.rocks/firefox" class="link-important">Download Firefox</a> (<a href="https://webvr.rocks/firefox#setup">read instructions</a>)
+            <a href="https://webvr.rocks/firefox" class="link-important">Download Firefox</a> and <a href="https://nightly.mozilla.org/">Firefox Nightly builds (Vive on macOS)</a> (<a href="https://webvr.rocks/firefox#setup">read instructions</a>)
           </li>
           <li>
             <a href="https://www.supermedium.com/" class="link-important">Download Supermedium</a>

--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@
                         <span class="carrot"></span>
                         <div class="device-box-header">Oculus Rift</div>
                         <span>
-                            Works with <a href="https://webvr.rocks/firefox">Firefox Nightly</a> and
+                            Works with <a href="https://webvr.rocks/firefox">Firefox</a> and
                             <a href="https://www.supermedium.com">Supermedium</a>
                             on Windows
                         </span>
@@ -109,10 +109,11 @@
                         <span class="carrot"></span>
                         <div class="device-box-header">HTC Vive</div>
                         <span>
-                            Works with <a href="https://webvr.rocks/firefox">Firefox Nightly</a>,
-                            <a href="https://blog.mozvr.com/webvr-servo-architecture-and-latency-optimizations/">Servo</a>, and
+                            Works with <a href="https://webvr.rocks/firefox">Firefox</a>,
+                            <a href="https://blog.mozvr.com/webvr-servo-architecture-and-latency-optimizations/">Servo</a> and
                             <a href="https://www.supermedium.com">Supermedium</a>
-                            on Windows
+                            on Windows.
+                            <a href="https://nightly.mozilla.org/">Firefox Nightly</a> on macOS.
                         </span>
                     </div>
                     <div class="device-box" onclick="this.classList.toggle('open');">
@@ -129,7 +130,7 @@
                         <div class="device-box-header">Windows Mixed Reality headsets</div>
                         <span>
                             <a href="https://docs.microsoft.com/en-us/microsoft-edge/webvr/webvr-with-edge/">Microsoft Edge supports WebVR</a>. <a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/status/webvr/">Status: "The WebVR 1.1 API is fully supported."</a>.
-                            <a href="https://www.supermedium.com">Supermedium</a> also supports through SteamVR.
+                            <a href="https://webvr.rocks/firefox">Firefox</a> and <a href="https://www.supermedium.com">Supermedium</a> also support through SteamVR.
                         </span>
                     </div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@
                         <span class="carrot"></span>
                         <div class="device-box-header">Samsung Gear VR</div>
                         <span>
-                            Works with <a href="https://www.oculus.com/experiences/gear-vr/1290985657630933/">Oculus Carmel</a> and <a href="https://www.oculus.com/experiences/gear-vr/849609821813454/">Samsung Internet</a>
+                            Works with <a href="https://www.oculus.com/experiences/gear-vr/1290985657630933/">Oculus Carmel</a> and <a href="https://www.oculus.com/experiences/gear-vr/849609821813454/">Samsung Internet</a>.
                         </span>
                     </div>
                     <div class="device-box" onclick="this.classList.toggle('open');">
@@ -99,7 +99,7 @@
                         <span>
                             Works with <a href="https://webvr.rocks/firefox">Firefox</a> and
                             <a href="https://www.supermedium.com">Supermedium</a>
-                            on Windows
+                            on Windows.
                         </span>
                     </div>
                 </div>
@@ -110,9 +110,9 @@
                         <div class="device-box-header">HTC Vive</div>
                         <span>
                             Works with <a href="https://webvr.rocks/firefox">Firefox</a>,
-                            <a href="https://blog.mozvr.com/webvr-servo-architecture-and-latency-optimizations/">Servo</a> and
+                            <a href="https://webvr.rocks/servo">Servo</a> and
                             <a href="https://www.supermedium.com">Supermedium</a>
-                            on Windows.
+                            on Windows.<br/>
                             <a href="https://nightly.mozilla.org/">Firefox Nightly</a> on macOS.
                         </span>
                     </div>
@@ -121,7 +121,7 @@
                         <span class="carrot"></span>
                         <div class="device-box-header">Playstation VR</div>
                         <span>
-                            Does not currently support WebVR
+                            Does not currently support WebVR.
                         </span>
                     </div>
                     <div class="device-box" onclick="this.classList.toggle('open');">
@@ -130,7 +130,7 @@
                         <div class="device-box-header">Windows Mixed Reality headsets</div>
                         <span>
                             <a href="https://docs.microsoft.com/en-us/microsoft-edge/webvr/webvr-with-edge/">Microsoft Edge supports WebVR</a>. <a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/status/webvr/">Status: "The WebVR 1.1 API is fully supported."</a>.
-                            <a href="https://webvr.rocks/firefox">Firefox</a> and <a href="https://www.supermedium.com">Supermedium</a> also support through SteamVR.
+                            <a href="https://webvr.rocks/firefox">Firefox</a> and <a href="https://www.supermedium.com">Supermedium</a> are also supported with <a href="https://docs.microsoft.com/en-us/windows/mixed-reality/enthusiast-guide/using-steamvr-with-windows-mixed-reality">SteamVR</a>.
                         </span>
                     </div>
                 </div>


### PR DESCRIPTION
Use release instead of nightly, and add reference to Vive support on macOS.